### PR TITLE
remove dependency on BinDeps

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.2
-BinDeps
-MathProgBase 0.3.0-dev1 0.4.0-
+julia 0.3
+MathProgBase 0.3.0 0.4.0-

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,12 +1,31 @@
-using BinDeps
-
-@BinDeps.setup
-
-libgurobi = library_dependency("libgurobi",aliases=["libgurobi51.so","gurobi51","libgurobi55.so","gurobi55","libgurobi56.so","gurobi56"])
-
-if haskey(ENV, "GUROBI_HOME")
-    @unix_only provides(Binaries, joinpath(ENV["GUROBI_HOME"],"lib"), libgurobi)
+depsfile = joinpath(dirname(@__FILE__),"deps.jl")
+if isfile(depsfile)
+    rm(depsfile)
 end
-@windows_only provides(Binaries, joinpath(ENV["GUROBI_HOME"],"bin"), libgurobi)
 
-@BinDeps.install [:libgurobi => :libgurobi]
+function write_depsfile(path)
+    f = open(depsfile,"w")
+    println(f,"const libgurobi = \"$path\"")
+    close(f)
+end
+
+aliases = ["gurobi56","gurobi55","gurobi51"]
+
+paths_to_try = [aliases]
+
+for a in aliases
+    if haskey(ENV, "GUROBI_HOME")
+        @unix_only push!(paths_to_try, joinpath(ENV["GUROBI_HOME"],"lib",string("lib",a,".so")))
+        @windows_only push!(paths_to_try, joinpath(ENV["GUROBI_HOME"],"bin",string(a,".",Sys.dlext)))
+    end
+    # gurobi uses .so on OS X for some reason
+    @osx_only push!(paths_to_try, string("lib$a.so"))
+end
+
+for l in paths_to_try
+    d = dlopen_e(l)
+    if d != C_NULL
+        write_depsfile(l)
+        break
+    end
+end


### PR DESCRIPTION
We can't leave this package broken for an extended period of time (it's been two weeks so far). BinDeps is also overkill for what we need, since we're just searching for the library that users have already installed. Let's test this on a few platforms. @IainNZ @joehuchette 
