### PR TITLE
Support Gurobi 6.0 and show an error if no binary found

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,7 +9,7 @@ function write_depsfile(path)
     close(f)
 end
 
-aliases = ["gurobi56","gurobi55","gurobi51","gurobi50"]
+aliases = ["gurobi60","gurobi56","gurobi55","gurobi51"]
 
 paths_to_try = [aliases]
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,7 +9,7 @@ function write_depsfile(path)
     close(f)
 end
 
-aliases = ["gurobi56","gurobi55","gurobi51"]
+aliases = ["gurobi56","gurobi55","gurobi51","gurobi50"]
 
 paths_to_try = [aliases]
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -22,10 +22,16 @@ for a in aliases
     @osx_only push!(paths_to_try, string("lib$a.so"))
 end
 
+found = false
 for l in paths_to_try
     d = dlopen_e(l)
     if d != C_NULL
+        found = true
         write_depsfile(l)
         break
     end
+end
+
+if ! found
+    error("No Gurobi found!")
 end


### PR DESCRIPTION
Corrects a problem I had: set the GUROBI_HOME environment variable, installed the Gurobi package, without problem, but unable to import the module! The error message urged me to install the package, but it happened without error: 

```
julia> import Gurobi
ERROR: Gurobi not properly installed. Please run Pkg.build("Gurobi")
 in error at error.jl:21
 in include at ./boot.jl:245
 in include_from_node1 at ./loading.jl:128
 in reload_path at loading.jl:152
 in _require at loading.jl:67
 in require at loading.jl:51
while loading /home/cuvelier/.julia/v0.3/Gurobi/src/Gurobi.jl, in expression starting on line 6
julia> Pkg.build("Gurobi")
INFO: Building Gurobi

julia>
```

This corrects my two problem: Gurobi 5.0 not being detected, no error message when it is not found. The test suite was run (include("~/.julia/v0.3/Gurobi/test/runtests.jl")) and ended without error message. 