### PR TITLE
drop support for gurobi 5.1

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ function write_depsfile(path)
     close(f)
 end
 
-aliases = ["gurobi60","gurobi56","gurobi55","gurobi51"]
+aliases = ["gurobi60","gurobi56","gurobi55"]
 
 paths_to_try = copy(aliases)
 


### PR DESCRIPTION
Gurobi 5.5 was released 2.5 years ago, so I think we can drop support for the previous version.