### PR TITLE
Update grb_model.jl

### DIFF
--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -25,7 +25,7 @@ module Gurobi
     getparam, setparam!, setparams!,
 
     # grb_model
-    set_sense!, update_model!, reset_model!, 
+    set_sense!, update_model!, reset_model!, get_tune_result!,
     read_model, write_model, tune_model, presolve_model, fixed_model,
 
     # grb_attrs

--- a/src/grb_model.jl
+++ b/src/grb_model.jl
@@ -131,6 +131,14 @@ function tune_model(model::Model)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
+    #####################################################
+    # Apply best parameters setting found with tunemodel 
+    # to the given model
+    ######################################################
+	ret = @grb_ccall(gettuneresult, Cint, (Ptr{Void}, Cint), model.ptr_model, 0)
+    if ret != 0
+        throw(GurobiError(model.env, ret))
+    end
     nothing
 end
 

--- a/src/grb_model.jl
+++ b/src/grb_model.jl
@@ -131,11 +131,11 @@ function tune_model(model::Model)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
-    #####################################################
-    # Apply best parameters setting found with tunemodel 
-    # to the given model
-    ######################################################
-	ret = @grb_ccall(gettuneresult, Cint, (Ptr{Void}, Cint), model.ptr_model, 0)
+    nothing
+end
+
+function get_tune_result!(model::Model,i::Int)
+    ret = @grb_ccall(gettuneresult, Cint, (Ptr{Void}, Cint), model.ptr_model, i)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end


### PR DESCRIPTION
There is a problem in the tune_model wrapper. A call to the gurobi function "tunemodel" does not affect the model but only computes an array of parameters settings. A subsequent call to "gettuneresult" is necessary if we want to apply the best parameters found to the given model.

Another way to accomplish this would be to encapsulate the call to "gettuneresult" within another julia wrapper.

Best wishes