### PR TITLE
Allow passing env to GurobiSolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,4 +436,19 @@ optimize(model)
 
 SOCP constraints of the form ``x'x <= y^2`` and ``x'x <= yz`` can be added using this method as well.
 
+### Reusing the same Gurobi environment for multiple solves
+
+When using this package via other packages such as [MathProgBase.jl](https://github.com/JuliaOpt/MathProgBase.jl) and [JuMP.jl](https://github.com/JuliaOpt/JuMP.jl), the default behavior is to obtain a new Gurobi license token every time a model is created and solved. If you are using Gurobi in a setting where the number of concurrent Gurobi uses is limited (e.g. ["Single-Use" or "Floating-Use" licenses](http://www.gurobi.com/products/licensing-pricing/licensing-overview)), you might instead prefer to obtain a single license token that is shared by all models that your program solves. You can do this by passing a Gurobi Environment object as the first parameter to `GurobiSolver`. For example, the follow code snippet solves multiple problems with JuMP using the same license token:
+
+```julia
+using JuMP, Gurobi
+env = Gurobi.Env()
+
+m1 = Model(solver=GurobiSolver(env))
+...
+
+# The solvers can have different options too
+m2 = Model(solver=GurobiSolver(env, OutputFlag=0))
+...
+```
 

--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -27,7 +27,7 @@ function GurobiMathProgModel(env=nothing;options...)
 end
 function setparams!(m::GurobiMathProgModel)
     # Helper to set the parameters on the model's copy of env rather than
-    # modifying the # global env (ref: http://www.gurobi.com/support/faqs#P)
+    # modifying the global env (ref: http://www.gurobi.com/support/faqs#P)
 
     # Set `InfUnbdInfo` to 1 by default so infeasibility rays available
     setparam!(m.inner, "InfUnbdInfo", 1)

--- a/test/env.jl
+++ b/test/env.jl
@@ -1,0 +1,28 @@
+using Gurobi, MathProgBase, FactCheck
+
+env = Gurobi.Env()
+
+# Test supplying environment manually
+
+solver = GurobiSolver(env)
+# Check that the env for each model is the same
+m1 = MathProgBase.LinearQuadraticModel(solver)
+@assert m1.inner.env === env
+m2 = MathProgBase.LinearQuadraticModel(solver)
+@assert m2.inner.env === env
+# Check that finalizer doesn't touch env when manually provided
+finalize(m1.inner)
+@assert Gurobi.is_valid(env)
+
+# Test creating environment automatically
+
+solver = GurobiSolver()
+# Check that the env for each model is different
+m3 = MathProgBase.LinearQuadraticModel(solver)
+@assert m3.inner.env !== env
+m4 = MathProgBase.LinearQuadraticModel(solver)
+@assert m4.inner.env !== env
+@assert m3.inner.env !== m4.inner.env
+# Check that env is finalized with model when not supplied manually
+finalize(m3.inner)
+@assert !Gurobi.is_valid(m3.inner.env)

--- a/test/env.jl
+++ b/test/env.jl
@@ -1,4 +1,4 @@
-using Gurobi, MathProgBase, FactCheck
+using Gurobi, MathProgBase
 
 env = Gurobi.Env()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,8 @@ tests = [
     "qp_02",
     "qcqp_01",
     "mathprog",
-    "test_grb_attrs"
+    "test_grb_attrs",
+    "env",
 ]
 
 for t in tests


### PR DESCRIPTION
This adds the option of passing a pre-existing `Gurobi.Env` as the first arg to `GurobiSolver`. Previously `env` would be created every time the `GurobiMathProgModel` was created, which was causing issues when using Gurobi with floating-use licences if models were being created at a very fast rate. This option allows you to use the recommended setup of a single env for multiple models to get around this ([ref](http://www.gurobi.com/documentation/6.5/refman/c_grbloadenv.html))

The only other change needed is to make sure that `finalize_env` is always false if the user supplied the `env`.

I can confirm that these changes have fixed the issues I was having, and that the tests are passing for me locally modulo #47. Do we need an explicit test for this and if so what should it test?

@mlubin 