### PR TITLE
Add catch for objective bug through MPB layer

### DIFF
--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -140,7 +140,7 @@ setconstrLB!(m::GurobiMathProgModel, lb) = (m.changed_constr_bounds = true; m.lb
 setconstrUB!(m::GurobiMathProgModel, ub) = (m.changed_constr_bounds = true; m.ub = copy(ub))
 
 getobj(m::GurobiMathProgModel)     = get_dblattrarray( m.inner, "Obj", 1, num_vars(m.inner)   )
-setobj!(m::GurobiMathProgModel, c) = (m.obj=c; set_dblattrarray!(m.inner, "Obj", 1, num_vars(m.inner), c))
+setobj!(m::GurobiMathProgModel, c) = (m.obj=copy(c); set_dblattrarray!(m.inner, "Obj", 1, num_vars(m.inner), c))
 
 function addvar!(m::GurobiMathProgModel, constridx, constrcoef, l, u, objcoef)
     if m.last_op_type == :Con
@@ -181,12 +181,12 @@ end
 function updatemodel!(m::GurobiMathProgModel)
     update_model!(m.inner)
     if m.obj != getobj(m)
-        @show m.obj, getobj(m)
         error("""
             You have encountered a known bug in Gurobi. Any information you query from the model may be incorrect.
             This bug has existed since the first version of Gurobi but is fixed in Gurobi v7.0.
 
             For more information go to https://github.com/JuliaOpt/Gurobi.jl/issues/60.
+            Please leave a comment stating that you encountered this bug! We would like to know how prevalent it is.
         """)
     end
     if m.changed_constr_bounds

--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -8,6 +8,7 @@ type GurobiMathProgModel <: AbstractLinearQuadraticModel
     last_op_type::Symbol  # To support arbitrary order of addVar/addCon
                           # Two possibilities :Var :Con
     changed_constr_bounds::Bool # have we updated the bounds below?
+    obj::Vector{Float64} # objective vector
     lb::Vector{Float64} # persistent bounds on constraints to maintain
     ub::Vector{Float64} # abstraction for lb ≤ Ax ≤ ub
     lazycb
@@ -21,7 +22,7 @@ function GurobiMathProgModel(env=nothing;options...)
    if env == nothing
        env = Env()
    end
-   m = GurobiMathProgModel(Model(env,""; finalize_env=finalize_env), :Con, false, Float64[], Float64[], nothing, nothing, nothing, nothing, options)
+   m = GurobiMathProgModel(Model(env,""; finalize_env=finalize_env), :Con, false, Float64[], Float64[], Float64[], nothing, nothing, nothing, nothing, options)
    setparams!(m)
    return m
 end
@@ -92,7 +93,7 @@ function loadproblem!(m::GurobiMathProgModel, A, collb, colub, obj, rowlb, rowub
   end
 
   m.lb, m.ub = rowlb, rowub
-
+  m.obj = obj
   update_model!(m.inner)
   setsense!(m,sense)
 end
@@ -139,13 +140,14 @@ setconstrLB!(m::GurobiMathProgModel, lb) = (m.changed_constr_bounds = true; m.lb
 setconstrUB!(m::GurobiMathProgModel, ub) = (m.changed_constr_bounds = true; m.ub = copy(ub))
 
 getobj(m::GurobiMathProgModel)     = get_dblattrarray( m.inner, "Obj", 1, num_vars(m.inner)   )
-setobj!(m::GurobiMathProgModel, c) = set_dblattrarray!(m.inner, "Obj", 1, num_vars(m.inner), c)
+setobj!(m::GurobiMathProgModel, c) = (m.obj=c; set_dblattrarray!(m.inner, "Obj", 1, num_vars(m.inner), c))
 
 function addvar!(m::GurobiMathProgModel, constridx, constrcoef, l, u, objcoef)
     if m.last_op_type == :Con
         updatemodel!(m)
         m.last_op_type = :Var
     end
+    push!(m.obj, objcoef)
     add_var!(m.inner, length(constridx), constridx, float(constrcoef), float(objcoef), float(l), float(u), GRB_CONTINUOUS)
 end
 function addvar!(m::GurobiMathProgModel, l, u, objcoef)
@@ -153,6 +155,7 @@ function addvar!(m::GurobiMathProgModel, l, u, objcoef)
         updatemodel!(m)
         m.last_op_type = :Var
     end
+    push!(m.obj, objcoef)
     add_var!(m.inner, 0, Integer[], Float64[], float(objcoef), float(l), float(u), GRB_CONTINUOUS)
 end
 function addconstr!(m::GurobiMathProgModel, varidx, coef, lb, ub)
@@ -177,6 +180,15 @@ end
 
 function updatemodel!(m::GurobiMathProgModel)
     update_model!(m.inner)
+    if m.obj != getobj(m)
+        @show m.obj, getobj(m)
+        error("""
+            You have encountered a known bug in Gurobi. Any information you query from the model may be incorrect.
+            This bug has existed since the first version of Gurobi but is fixed in Gurobi v7.0.
+
+            For more information go to https://github.com/JuliaOpt/Gurobi.jl/issues/60.
+        """)
+    end
     if m.changed_constr_bounds
     # update lower/upper bounds on linear constraints (if they're consistent...)
         sense = get_charattrarray(m.inner, "Sense", 1, num_constrs(m.inner))

--- a/test/reformulation_bug.jl
+++ b/test/reformulation_bug.jl
@@ -1,0 +1,23 @@
+using Gurobi, MathProgBase
+
+m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+
+# Max           z
+# s.t.  x + y     >= 0
+#       x + y     >= 0
+#      2x - y     >= 0
+#       x     - z >= 0
+#               z >= -10
+# x ∈ [0, 1], y ∈ [0, ∞), z \in (-∞, 1]
+MathProgBase.loadproblem!(m, [1 1 0; 1 1 0; 2 -1 0; 1 0 -1; 0 0 1], [0, 0, -Inf],[1,Inf,1], [0,0,1], [0,0,0,0,-10], [Inf,Inf,Inf,Inf,Inf], :Max)
+
+MathProgBase.optimize!(m)
+
+MathProgBase.addconstr!(m, [1, 2, 3], [-1.0000019, 1., -1.], 0., Inf)
+
+MathProgBase.optimize!(m)
+
+obj = MathProgBase.getobj(m)
+MathProgBase.setobj!(m, obj)
+
+MathProgBase.optimize!(m)


### PR DESCRIPTION
See https://github.com/JuliaOpt/Gurobi.jl/issues/60

The alternative is catching this at the C interface level. However I went this (quick) route first because I presume/hope no one is using Gurobi.jl by itself. Going the C route would involve catching the setAttr functions that can be used to modify the objective as well as the add variable functions.

This bug has existed since the very first version of Gurobi. Some sort of catch definitely needs to go in. Gurobi ends up solving a different problem to the one you specify so without it we really have no idea of the frequency of this occurrence.

@mlubin 