### PR TITLE
Stop reformulation bug error triggering on range constraints

### DIFF
--- a/test/range_constraints.jl
+++ b/test/range_constraints.jl
@@ -1,0 +1,6 @@
+using Gurobi, MathProgBase
+
+# Test Range constraints pass
+m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+MathProgBase.loadproblem!(m, [1 1], [0, 0],[1,1], [1,1], [0], [1], :Max)
+MathProgBase.optimize!(m)

--- a/test/reformulation_bug.jl
+++ b/test/reformulation_bug.jl
@@ -1,5 +1,8 @@
 using Gurobi, MathProgBase
 
+# This problem should error out on Gurobi Versions 6.5.2 and earlier,
+# but pass on later versions
+
 m = MathProgBase.LinearQuadraticModel(GurobiSolver())
 
 # Max           z

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ tests = [
     "mathprog",
     "test_grb_attrs",
     "env",
+    "range_constraints"
 ]
 
 for t in tests


### PR DESCRIPTION
The reformulation bug (https://github.com/JuliaOpt/Gurobi.jl/issues/60) error message was being triggered by the additional slack variables introduced by range constraints.

Tests pass on my local machine.