### PR TITLE
fix for promotion changes in 0.6

### DIFF
--- a/src/grb_callbacks.jl
+++ b/src/grb_callbacks.jl
@@ -39,7 +39,7 @@ for f in (:cbcut, :cblazy)
         @assert length(val) == len
 
         ret = @grb_ccall($f, Cint, (Ptr{Void},Cint,Ptr{Cint},Ptr{Float64},
-            Char,Float64), cbdata.cbdata, len, ind.-1, val, sense, rhs)
+            Char,Float64), cbdata.cbdata, len, ind-Cint(1), val, sense, rhs)
         if ret != 0
             throw(GurobiError(cbdata.model.env, ret))
         end

--- a/src/grb_constrs.jl
+++ b/src/grb_constrs.jl
@@ -13,7 +13,7 @@ function add_constr!(model::Model, inds::IVec, coeffs::FVec, rel::Cchar, rhs::Fl
         Float64,      # rhs
         Ptr{UInt8}    # name
         ),
-        model, length(inds), inds - 1, coeffs, rel, rhs, C_NULL)
+        model, length(inds), inds - Cint(1), coeffs, rel, rhs, C_NULL)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -49,7 +49,7 @@ function add_constrs!(model::Model, cbegins::IVec, inds::IVec, coeffs::FVec, rel
             Ptr{Float64}, # rhs
             Ptr{UInt8}    # names
             ),
-            model, m, nnz, cbegins - 1, inds - 1, coeffs,
+            model, m, nnz, cbegins - Cint(1), inds - Cint(1), coeffs,
             rel, rhs, C_NULL)
 
         if ret != 0
@@ -94,7 +94,7 @@ function add_rangeconstr!(model::Model, inds::IVec, coeffs::FVec, lb::Float64, u
         Float64,      # upper
         Ptr{UInt8}    # name
         ),
-        model, length(inds), inds - 1, coeffs, lb, ub, C_NULL)
+        model, length(inds), inds - Cint(1), coeffs, lb, ub, C_NULL)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -131,7 +131,7 @@ function add_rangeconstrs!(model::Model, cbegins::IVec, inds::IVec, coeffs::FVec
             Ptr{Float64}, # upper
             Ptr{UInt8}    # names
             ),
-            model, m, nnz, cbegins - 1, inds - 1, coeffs, lb, ub, C_NULL)
+            model, m, nnz, cbegins - Cint(1), inds - Cint(1), coeffs, lb, ub, C_NULL)
 
         if ret != 0
             throw(GurobiError(model.env, ret))
@@ -223,7 +223,7 @@ function del_constrs!(model::Model, idx::Vector{Cint})
                      Ptr{Void},
                      Cint,
                      Ptr{Cint}),
-                     model, convert(Cint,numdel), idx.-1)
+                     model, convert(Cint,numdel), idx-Cint(1))
     if ret != 0
         throw(GurobiError(model.env, ret))
     end

--- a/src/grb_quad.jl
+++ b/src/grb_quad.jl
@@ -13,7 +13,7 @@ function add_qpterms!(model::Model, qr::IVec, qc::IVec, qv::FVec)
             Ptr{Cint},    # qcol
             Ptr{Float64}, # qval
             ), 
-            model, nnz, qr.-1, qc.-1, qv)
+            model, nnz, qr-Cint(1), qc-Cint(1), qv)
             
         if ret != 0
             throw(GurobiError(model.env, ret))
@@ -167,7 +167,7 @@ function add_qconstr!(model::Model, lind::IVec, lval::FVec, qr::IVec, qc::IVec, 
             Float64,      # rhs
             Ptr{UInt8}    # name
             ), 
-            model, lnnz, lind.-1, lval, qnnz, qr.-1, qc.-1, qv, rel, rhs, C_NULL)
+            model, lnnz, lind-Cint(1), lval, qnnz, qr-Cint(1), qc-Cint(1), qv, rel, rhs, C_NULL)
             
         if ret != 0
             throw(GurobiError(model.env, ret))

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -19,7 +19,7 @@ function add_var!(model::Model, numnz::Integer, vind::Vector, vval::Vector{Float
         UInt8,        # vtype
         Ptr{UInt8}    # name
         ), 
-        model, numnz, ivec(vind.-1), vval, obj, lb, ub, vtype, C_NULL)
+        model, numnz, ivec(vind-1), vval, obj, lb, ub, vtype, C_NULL)
         
     if ret != 0
         throw(GurobiError(model.env, ret))


### PR DESCRIPTION
``Int32[1,2,3] .- 1`` will now promote the answer to an ``Int64`` array which means that junk was being fed into the C calls.

CC @joehuchette, likely also relevant to cplex.