### PR TITLE
Fix loadproblem! from file

### DIFF
--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -79,7 +79,12 @@ function setparameters!(m::GurobiMathProgModel; mpboptions...)
     end
 end
 
-loadproblem!(m::GurobiMathProgModel, filename::AbstractString) = read_model(m.inner, filename)
+function loadproblem!(m::GurobiMathProgModel, filename::AbstractString)
+    read_model(m.inner, filename)
+    m.obj = getobj(m)
+    m.lb = getconstrLB(m)
+    m.ub = getconstrUB(m)
+end
 
 function loadproblem!(m::GurobiMathProgModel, A, collb, colub, obj, rowlb, rowub, sense)
   # throw away old model but keep env and finalize_env


### PR DESCRIPTION
When `loadproblem!` is called with a file, `lb`, `ub` and `obj` do not correspond to the internal value of Gurobi. This PR fixes this by setting them to nothing to show that they do not represent the internal value and set them to the internal value when needed.