### PR TITLE
add more status codes

### DIFF
--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -318,6 +318,10 @@ function status(m::GurobiMathProgModel)
     return :Suboptimal # not very useful status
   elseif s == :interrupted # ended by user?
     return :UserLimit
+  elseif s == :inprogress
+      return :InProgress
+  elseif s == :user_obj_limit
+      return :UserObjLimit
   else
     error("Unrecognized solution status: $s")
   end

--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -319,9 +319,9 @@ function status(m::GurobiMathProgModel)
   elseif s == :interrupted # ended by user?
     return :UserLimit
   elseif s == :inprogress
-      return :InProgress
+    return :InProgress
   elseif s == :user_obj_limit
-      return :UserObjLimit
+    return :UserObjLimit
   else
     error("Unrecognized solution status: $s")
   end

--- a/src/grb_solve.jl
+++ b/src/grb_solve.jl
@@ -38,6 +38,8 @@ const GRB_SOLUTION_LIMIT  = 10
 const GRB_INTERRUPTED     = 11
 const GRB_NUMERIC         = 12
 const GRB_SUBOPTIMAL      = 13
+const GRB_INPROGRESS      = 14
+const GRB_USER_OBJ_LIMIT  = 15
 
 const status_symbols = [
     :loaded, 
@@ -52,7 +54,9 @@ const status_symbols = [
     :solution_limit,
     :interrupted,
     :numeric,
-    :suboptimal
+    :suboptimal,
+    :inprogress,
+    :user_obj_limit
 ]
 
 get_status_code(model::Model) = get_intattr(model, "Status")


### PR DESCRIPTION
This pull request adds a couple status codes that are documented [here](https://www.gurobi.com/documentation/7.0/refman/optimization_status_codes.html). The last status code seems to be required to use the [BestObjStop](http://www.gurobi.com/documentation/7.0/refman/bestobjstop.html#parameter:BestObjStop) option like `Gurobi.GurobiSolver(BestObjStop=...)`.