### PR TITLE
Add warnings when using large coefficients

### DIFF
--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -160,16 +160,11 @@ function loadproblem!(m::GurobiMathProgModel, A, collb, colub, obj, rowlb, rowub
   update_model!(m.inner)
   setsense!(m,sense)
 end
-function _truncateobj!(obj::Vector)
-    for i in eachindex(obj)
-        if obj[i] > GRB_INFINITY
-            obj[i] = GRB_INFINITY
-        elseif obj[i] < -GRB_INFINITY
-            obj[i] = -GRB_INFINITY
-        end
-    end
-end
+
 function _truncateobj(v::Real)
+    # Gurobi truncates objective coefficients to +/-GRB_INFINITY
+    # We need to do this to the m.obj vector for consistency
+    #   see #94
     if v > GRB_INFINITY
         return GRB_INFINITY
     elseif v < -GRB_INFINITY
@@ -177,6 +172,8 @@ function _truncateobj(v::Real)
     end
     return v
 end
+_truncateobj!(obj::Vector) = map!(_truncateobj, obj, obj)
+
 writeproblem(m::GurobiMathProgModel, filename::AbstractString) = write_model(m.inner, filename)
 
 getvarLB(m::GurobiMathProgModel)     = get_dblattrarray( m.inner, "LB", 1, num_vars(m.inner))

--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -180,10 +180,20 @@ _truncateobj!(obj::Vector) = map!(_truncateobj, obj, obj)
 writeproblem(m::GurobiMathProgModel, filename::AbstractString) = write_model(m.inner, filename)
 
 getvarLB(m::GurobiMathProgModel)     = get_dblattrarray( m.inner, "LB", 1, num_vars(m.inner))
-setvarLB!(m::GurobiMathProgModel, l) = set_dblattrarray!(m.inner, "LB", 1, num_vars(m.inner), l)
+function setvarLB!(m::GurobiMathProgModel, l)
+    if checkvalue(l, GRB_BOUNDMAX)
+        _boundwarning(l, getvarUB(m))
+    end
+    set_dblattrarray!(m.inner, "LB", 1, num_vars(m.inner), l)
+end
 
 getvarUB(m::GurobiMathProgModel)     = get_dblattrarray( m.inner, "UB", 1, num_vars(m.inner))
-setvarUB!(m::GurobiMathProgModel, u) = set_dblattrarray!(m.inner, "UB", 1, num_vars(m.inner), u)
+function setvarUB!(m::GurobiMathProgModel, u)
+    if checkvalue(u, GRB_BOUNDMAX)
+        _boundwarning(getvarLB(m), u)
+    end
+    set_dblattrarray!(m.inner, "UB", 1, num_vars(m.inner), u)
+end
 
 function getconstrLB(m::GurobiMathProgModel)
     sense = get_charattrarray(m.inner, "Sense", 1, num_constrs(m.inner))

--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -104,6 +104,9 @@ end
 function loadproblem!(m::GurobiMathProgModel, filename::AbstractString)
     read_model(m.inner, filename)
     m.obj = getobj(m)
+    if checkvalue(m.obj, GRB_INFINITY)
+        _objwarning(m.obj)
+    end
     _truncateobj!(m.obj)
     m.lb = getconstrLB(m)
     m.ub = getconstrUB(m)
@@ -217,6 +220,9 @@ setconstrUB!(m::GurobiMathProgModel, ub) = (m.changed_constr_bounds = true; m.ub
 
 getobj(m::GurobiMathProgModel)     = get_dblattrarray( m.inner, "Obj", 1, num_vars(m.inner)   )
 function setobj!(m::GurobiMathProgModel, c)
+    if checkvalue(c, GRB_INFINITY)
+        _objwarning(c)
+    end
     m.obj = copy(c)
     _truncateobj!(m.obj)
     set_dblattrarray!(m.inner, "Obj", 1, num_vars(m.inner), c)

--- a/src/grb_common.jl
+++ b/src/grb_common.jl
@@ -73,3 +73,15 @@ const version = getlibversion()
 
 const GRB_INFINITY = 1e100
 const GRB_BOUNDMAX = 1e30
+function checkvalue(x::Real, bound)
+    abs(x) > bound && abs(x) != Inf
+end
+checkvalue(x::Vector, bound) = any(checkvalue(c, bound) for c in x)
+
+_objwarning(c) = warn("""Gurobi will silently silently truncate objective coefficients >$(GRB_INFINITY) or <-$(GRB_INFINITY).
+Current objective coefficient extrema: $(extrema(c))""")
+
+_boundwarning(lb, ub) = warn("""Gurobi has implicit variable bounds of [-1e30, 1e30].
+Settings variable bounds outside this can cause infeasibility or unboundedness.
+Current lower bound extrema: $(extrema(lb))
+Current upper bound extrema: $(extrema(ub))""")

--- a/src/grb_common.jl
+++ b/src/grb_common.jl
@@ -64,10 +64,12 @@ function getlibversion()
     _minor = Cint[0]
     _tech = Cint[0]
     @grb_ccall(version, Void, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), _major, _minor, _tech)
-    return VersionNumber(_major[1], _minor[1], _tech[1])        
+    return VersionNumber(_major[1], _minor[1], _tech[1])
 end
 
 # version need not be export
 # one can write Gurobi.version to get the version numbers
 const version = getlibversion()
 
+const GRB_INFINITY = 1e100
+const GRB_BOUNDMAX = 1e30

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -6,8 +6,26 @@ const GRB_CONTINUOUS = convert(Cchar, 'C')
 const GRB_BINARY     = convert(Cchar, 'B')
 const GRB_INTEGER    = convert(Cchar, 'I')
 
+function checkvalue(x, bound)
+    abs(x) > bound && abs(x) != Inf
+end
+
+_objwarning(c) = warn("""Gurobi will silently silently truncate objective coefficients >$(GRB_INFINITY) or <-$(GRB_INFINITY).
+Current objective coefficient extrema: $(extrema(c))""")
+
+_boundwarning(lb, ub) = warn("""Gurobi has implicit variable bounds of [-1e30, 1e30].
+Settings variable bounds outside this can cause infeasibility or unboundedness.
+Current lower bound extrema: $(extrema(lb))
+Current upper bound extrema: $(extrema(ub))""")
+
 # add_var!
-function add_var!(model::Model, numnz::Integer, vind::Vector, vval::Vector{Float64}, obj::Float64, lb::Float64, ub::Float64, vtype::Cchar)
+function add_var!(model::Model, numnz::Integer, vind::Vector, vval::Vector{Float64}, c::Float64, lb::Float64, ub::Float64, vtype::Cchar)
+    if checkvalue(c, GRB_INFINITY)
+        _objwarning(c)
+    end
+    if checkvalue(lb, GRB_BOUNDMAX) || checkvalue(ub, GRB_BOUNDMAX)
+        _boundwarning(lb, ub)
+    end
     ret = @grb_ccall(addvar, Cint, (
         Ptr{Void},    # model
         Cint,         # numnz
@@ -18,16 +36,22 @@ function add_var!(model::Model, numnz::Integer, vind::Vector, vval::Vector{Float
         Float64,      # ub
         UInt8,        # vtype
         Ptr{UInt8}    # name
-        ), 
-        model, numnz, ivec(vind-1), vval, obj, lb, ub, vtype, C_NULL)
-        
+        ),
+        model, numnz, ivec(vind-1), vval, c, lb, ub, vtype, C_NULL)
+
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
     nothing
 end
 
-function add_var!(model::Model, vtype::Cchar, c::Float64, lb::Float64, ub::Float64)    
+function add_var!(model::Model, vtype::Cchar, c::Float64, lb::Float64, ub::Float64)
+    if checkvalue(c, GRB_INFINITY)
+        _objwarning(c)
+    end
+    if checkvalue(lb, GRB_BOUNDMAX) || checkvalue(ub, GRB_BOUNDMAX)
+        _boundwarning(lb, ub)
+    end
     ret = @grb_ccall(addvar, Cint, (
         Ptr{Void},    # model
         Cint,         # numnz
@@ -38,18 +62,16 @@ function add_var!(model::Model, vtype::Cchar, c::Float64, lb::Float64, ub::Float
         Float64,      # ub
         UInt8,        # vtype
         Ptr{UInt8}    # name
-        ), 
+        ),
         model, 0, C_NULL, C_NULL, c, lb, ub, vtype, C_NULL)
-        
+
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
     nothing
 end
 
-function add_var!(model::Model, vtype::GChars, c::Real, lb::Real, ub::Real)
-    add_var!(model, cchar(vtype), Float64(c), Float64(lb), Float64(ub))
-end
+add_var!(model::Model, vtype::GChars, c::Real, lb::Real, ub::Real) = add_var!(model, cchar(vtype), Float64(c), Float64(lb), Float64(ub))
 add_var!(model::Model, vtype::GChars, c::Real) = add_var!(model, vtype, c, -Inf, Inf)
 
 add_cvar!(model::Model, c::Real, lb::Real, ub::Real) = add_var!(model, GRB_CONTINUOUS, c, lb, ub)
@@ -64,9 +86,14 @@ add_ivar!(model::Model, c::Real) = add_ivar!(model, c, -Inf, Inf)
 # add_vars!
 
 function add_vars!(model::Model, vtypes::CVec, c::FVec, lb::FVec, ub::FVec)
-    
+    if any(checkvalue(obj, GRB_INFINITY) for obj in c)
+        _objwarning(c)
+    end
+    if any(checkvalue(b, GRB_BOUNDMAX) for b in lb) || any(checkvalue(b, GRB_BOUNDMAX) for b in ub)
+        _boundwarning(lb, ub)
+    end
     # check dimensions
-    n = length(vtypes)    
+    n = length(vtypes)
     _chklen(c, n)
     _chklen(lb, n)
     _chklen(ub, n)
@@ -84,9 +111,9 @@ function add_vars!(model::Model, vtypes::CVec, c::FVec, lb::FVec, ub::FVec)
         Ptr{Float64}, # ub
         Ptr{Cchar},   # vtypes
         Ptr{Ptr{UInt8}}, # varnames
-        ), 
+        ),
         model, n, 0, C_NULL, C_NULL, C_NULL, c, lb, ub, vtypes, C_NULL)
-        
+
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -104,7 +131,7 @@ add_cvars!(model::Model, c::Vector) = add_cvars!(model, c, -Inf, Inf)
 add_bvars!(model::Model, c::Vector) = add_vars!(model, GRB_BINARY, c, 0, 1)
 
 add_ivars!(model::Model, c::Vector, lb::Bounds, ub::Bounds) = add_vars!(model, GRB_INTEGER, c, lb, ub)
-add_ivars!(model::Model, c::Vector) = add_ivars!(model, GRB_INTEGER, c, -Inf, Inf) 
+add_ivars!(model::Model, c::Vector) = add_ivars!(model, GRB_INTEGER, c, -Inf, Inf)
 
 del_vars!{T<:Real}(model::Model, idx::T) = del_vars!(model, Cint[idx])
 del_vars!{T<:Real}(model::Model, idx::Vector{T}) = del_vars!(model, convert(Vector{Cint},idx))

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -6,18 +6,6 @@ const GRB_CONTINUOUS = convert(Cchar, 'C')
 const GRB_BINARY     = convert(Cchar, 'B')
 const GRB_INTEGER    = convert(Cchar, 'I')
 
-function checkvalue(x, bound)
-    abs(x) > bound && abs(x) != Inf
-end
-
-_objwarning(c) = warn("""Gurobi will silently silently truncate objective coefficients >$(GRB_INFINITY) or <-$(GRB_INFINITY).
-Current objective coefficient extrema: $(extrema(c))""")
-
-_boundwarning(lb, ub) = warn("""Gurobi has implicit variable bounds of [-1e30, 1e30].
-Settings variable bounds outside this can cause infeasibility or unboundedness.
-Current lower bound extrema: $(extrema(lb))
-Current upper bound extrema: $(extrema(ub))""")
-
 # add_var!
 function add_var!(model::Model, numnz::Integer, vind::Vector, vval::Vector{Float64}, c::Float64, lb::Float64, ub::Float64, vtype::Cchar)
     if checkvalue(c, GRB_INFINITY)
@@ -86,10 +74,10 @@ add_ivar!(model::Model, c::Real) = add_ivar!(model, c, -Inf, Inf)
 # add_vars!
 
 function add_vars!(model::Model, vtypes::CVec, c::FVec, lb::FVec, ub::FVec)
-    if any(checkvalue(obj, GRB_INFINITY) for obj in c)
+    if checkvalue(c, GRB_INFINITY)
         _objwarning(c)
     end
-    if any(checkvalue(b, GRB_BOUNDMAX) for b in lb) || any(checkvalue(b, GRB_BOUNDMAX) for b in ub)
+    if checkvalue(lb, GRB_BOUNDMAX) || checkvalue(ub, GRB_BOUNDMAX)
         _boundwarning(lb, ub)
     end
     # check dimensions

--- a/test/large_coefficients.jl
+++ b/test/large_coefficients.jl
@@ -1,0 +1,53 @@
+using Gurobi, MathProgBase, Base.Test
+
+@testset "Large Coefficients" begin
+
+    @testset "Large Objective Coefficients" begin
+        # Min   1.1e100x
+        #       x >= 1
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [1],[Inf], [1.1e100], Float64[], Float64[], :Min)
+        MathProgBase.optimize!(m)
+        @test MathProgBase.getsolution(m) == [1.0]
+        @test MathProgBase.getobjval(m) == 1e100
+
+        # Max   -1.1e100x
+        #       x >= 1
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [1],[Inf], [-1.1e100], Float64[], Float64[], :Max)
+        MathProgBase.optimize!(m)
+        @test MathProgBase.getsolution(m) == [1.0]
+        @test MathProgBase.getobjval(m) == -1e100
+    end
+
+    @testset "Large Variable Bounds" begin
+        # Min   x
+        #       x >= 1.1e30
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [1.1e30],[Inf], [1], Float64[], Float64[], :Min)
+        MathProgBase.optimize!(m)
+        @test MathProgBase.status(m) == :Infeasible
+
+        # Max   x
+        #       x <= -1.1e30
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [-Inf],[-1.1e30], [1], Float64[], Float64[], :Max)
+        MathProgBase.optimize!(m)
+        @test MathProgBase.status(m) == :Infeasible
+
+        # Min   x
+        #       x >= -1.1e30
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [-1.1e30],[Inf], [1], Float64[], Float64[], :Min)
+        MathProgBase.optimize!(m)
+        @test MathProgBase.status(m) == :Unbounded
+
+        # Max   x
+        #       x <= 1.1e30
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [-Inf],[1.1e30], [1], Float64[], Float64[], :Max)
+        MathProgBase.optimize!(m)
+        @test MathProgBase.status(m) == :Unbounded
+
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,8 @@ tests = [
     "test_grb_attrs",
     "env",
     "range_constraints",
-    "test_get_strarray"
+    "test_get_strarray",
+    "large_coefficients"
 ]
 
 for t in tests


### PR DESCRIPTION
As [stated by Gurobi](https://groups.google.com/forum/#!topic/gurobi/M_Bzc6RWMhU), "everything that is larger than 1e+100 is silently converted into 1e+100. For bounds, the value is actually 1e+30. So, every bound value that is larger than 1e+30 (smaller than -1e+30) is truncated to 1e+30 (-1e+30)."

This pull requests introduces a warning rather than silently failing. It is made slightly more complicated by the fact we have to propagate the truncation through the `m.obj` vector we keep around to verify Gurobi stores the correct objective.

Closes https://github.com/JuliaOpt/Gurobi.jl/issues/94.