### PR TITLE
Fix deprecation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5
 MathProgBase 0.5 0.7
+Compat 0.18

--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -12,11 +12,13 @@ module Gurobi
 
     import Base.show, Base.copy
 
+    using Compat
+
     # Standard LP interface
     importall MathProgBase.SolverInterface
 
     ### exports
-    export 
+    export
 
     # grb_env
     free_env,
@@ -44,7 +46,7 @@ module Gurobi
     del_vars!,
 
     # grb_constrs
-    add_constr!, add_constrs!, add_constrs_t!, 
+    add_constr!, add_constrs!, add_constrs_t!,
     add_rangeconstr!, add_rangeconstrs!, add_rangeconstrs_t!,
     get_constrmatrix, add_sos!, del_constrs!, chg_coeffs!,
 
@@ -57,7 +59,7 @@ module Gurobi
     # grb_solve
     optimize, computeIIS, get_solution,
     get_status, OptimInfo, get_optiminfo, get_objval
-    
+
 
     ### include source files
 

--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -127,7 +127,7 @@ function loadproblem!(m::GurobiMathProgModel, A, collb, colub, obj, rowlb, rowub
   # check if we have any range constraints
   # to properly support these, we will need to keep track of the
   # slack variables automatically added by gurobi.
-  rangeconstrs = sum((rowlb .!= rowub) & (rowlb .> neginf) & (rowub .< posinf))
+  rangeconstrs = sum((rowlb .!= rowub) .& (rowlb .> neginf) .& (rowub .< posinf))
   if rangeconstrs > 0
       warn("Julia Gurobi interface doesn't properly support range (two-sided) constraints. See Gurobi.jl issue #14")
       add_rangeconstrs!(m.inner, float(A), float(rowlb), float(rowub))

--- a/src/grb_attrs.jl
+++ b/src/grb_attrs.jl
@@ -135,7 +135,7 @@ end
 
 function get_strattrarray(model::Model, name::String, start::Integer, len::Integer)
     @assert isascii(name)
-    get_strattrarray!(Array(Ptr{UInt8}, len), model, name, start)
+    get_strattrarray!(Array{Ptr{UInt8}}(len), model, name, start)
 end
 
 function get_strattrarray!(r::Array{Ptr{UInt8}}, model::Model, name::String, start::Integer)
@@ -359,4 +359,3 @@ function show(io::IO, model::Model)
         println(io, "Gurobi Model: NULL")
     end
 end
-

--- a/src/grb_common.jl
+++ b/src/grb_common.jl
@@ -2,15 +2,15 @@
 
 ## convenient types and type conversion functions
 
-typealias GChars Union{Cchar, Char}
-typealias IVec Vector{Cint}
-typealias FVec Vector{Float64}
-typealias CVec Vector{Cchar}
+const GChars          = Union{Cchar, Char}
+const IVec            = Vector{Cint}
+const FVec            = Vector{Float64}
+const CVec            = Vector{Cchar}
 
-typealias GCharOrVec Union{Cchar, Char, Vector{Cchar}, Vector{Char}}
+const GCharOrVec      = Union{Cchar, Char, Vector{Cchar}, Vector{Char}}
 
-typealias Bounds{T<:Real} Union{T, Vector{T}}
-typealias CoeffMat Union{Matrix{Float64}, SparseMatrixCSC{Float64}}
+@compat const Bounds{T<:Real} = Union{T, Vector{T}}
+const CoeffMat        = Union{Matrix{Float64}, SparseMatrixCSC{Float64}}
 
 cchar(c::Cchar) = c
 cchar(c::Char) = convert(Cchar, c)
@@ -64,10 +64,9 @@ function getlibversion()
     _minor = Cint[0]
     _tech = Cint[0]
     @grb_ccall(version, Void, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), _major, _minor, _tech)
-    return VersionNumber(_major[1], _minor[1], _tech[1])        
+    return VersionNumber(_major[1], _minor[1], _tech[1])
 end
 
 # version need not be export
 # one can write Gurobi.version to get the version numbers
 const version = getlibversion()
-

--- a/test/lp_02.jl
+++ b/test/lp_02.jl
@@ -29,6 +29,6 @@ using MathProgBase, Gurobi, Base.Test
 
 	optimize(model)
 
-	@test_approx_eq_eps get_solution(model) [59.0909, 36.3636] 1e-4
-	@test_approx_eq_eps get_objval(model) 71818.1818 1e-4
+	@test isapprox(get_solution(model), [59.0909, 36.3636], atol=1e-4)
+	@test isapprox(get_objval(model), 71818.1818, atol=1e-4)
 end

--- a/test/lp_04.jl
+++ b/test/lp_04.jl
@@ -38,16 +38,16 @@ using Gurobi, Base.Test
     # perform optimization
     optimize(model)
 
-    @test_approx_eq_eps get_solution(model) [1.3333, 1.3333] 1e-4
-    @test_approx_eq_eps get_objval(model) 2.6666 1e-4
+    @test isapprox(get_solution(model), [1.3333, 1.3333], atol=1e-4)
+    @test isapprox(get_objval(model), 2.6666, atol=1e-4)
 
     # PART 2:
     # copy and solve
 
     model2 = copy(model)
     optimize(model2)
-    @test_approx_eq_eps get_solution(model2) [1.3333, 1.3333] 1e-4
-    @test_approx_eq_eps get_objval(model2) 2.6666 1e-4
+    @test isapprox(get_solution(model2), [1.3333, 1.3333], atol=1e-4)
+    @test isapprox(get_objval(model2), 2.6666, atol=1e-4)
 
     # PART 3:
     # change coeff and solve
@@ -68,7 +68,7 @@ using Gurobi, Base.Test
     @test !any(sol .< 0)
     @test !any(sol .> 2)
     @test sum(sol) == 2.0
-    @test_approx_eq_eps get_objval(model) 2.0 1e-4
+    @test isapprox(get_objval(model), 2.0, atol=1e-4)
 
     # PART 4:
     # del constr and solve
@@ -83,8 +83,8 @@ using Gurobi, Base.Test
     del_constrs!(model, [1])
     update_model!(model)
     optimize(model)
-    @test_approx_eq_eps get_solution(model) [4.0, 0.0] 1e-4
-    @test_approx_eq_eps get_objval(model) 4.0 1e-4
+    @test isapprox(get_solution(model), [4.0, 0.0], atol=1e-4)
+    @test isapprox(get_objval(model), 4.0, atol=1e-4)
 
     # PART 5:
     # del var and solve
@@ -99,8 +99,8 @@ using Gurobi, Base.Test
     del_vars!(model, [1])
     update_model!(model)
     optimize(model)
-    @test_approx_eq_eps get_solution(model) [2.0] 1e-4
-    @test_approx_eq_eps get_objval(model) 2.0 1e-4
+    @test isapprox(get_solution(model), [2.0], atol=1e-4)
+    @test isapprox(get_objval(model), 2.0, atol=1e-4)
 
     gc()  # test finalizers
 end

--- a/test/qcqp_01.jl
+++ b/test/qcqp_01.jl
@@ -25,6 +25,6 @@ using Gurobi, Base.Test
 
     optimize(model)
 
-    @test_approx_eq_eps get_solution(model) [0.707107, 0.707107] 1e-5
-    @test_approx_eq_eps get_objval(model) 1.414214 1e-5
+    @test isapprox(get_solution(model), [0.707107, 0.707107], atol=1e-5)
+    @test isapprox(get_objval(model), 1.414214, atol=1e-5)
 end

--- a/test/qp_01.jl
+++ b/test/qp_01.jl
@@ -27,6 +27,6 @@ using Gurobi, Base.Test
 
     optimize(model)
 
-    @test_approx_eq_eps get_solution(model) [0.25, 0.75] 1e-4
+    @test isapprox(get_solution(model), [0.25, 0.75], atol=1e-4)
     @test get_objval(model) == 1.875
 end

--- a/test/qp_02.jl
+++ b/test/qp_02.jl
@@ -21,6 +21,6 @@ using Gurobi, Base.Test
 
 	optimize(model)
 
-	@test_approx_eq_eps get_solution(model) [0.571429,0.428571,0.857143] 1e-5
-	@test_approx_eq_eps get_objval(model) 1.857143 1e-5
+	@test isapprox(get_solution(model), [0.571429,0.428571,0.857143], atol=1e-5)
+	@test isapprox(get_objval(model), 1.857143, atol=1e-5)
 end


### PR DESCRIPTION
Earliest Compat version is 0.18: https://github.com/JuliaLang/Compat.jl/commit/3866f8b9c43a9c5a4b99bb2f6133340eaa1bbce7

Passes tests on 0.6 and 0.5.