### PR TITLE
make it possible to silence gurobi environment construction

### DIFF
--- a/src/grb_env.jl
+++ b/src/grb_env.jl
@@ -3,11 +3,40 @@
 
 type Env
     ptr_env::Ptr{Void}
-    
-    function Env()
+
+    """
+        Env(silent::Bool=false)
+
+    Construct a Gurobi environment. The environment maintains parameters of the
+    Gurobi solver and its license. In particular, constructing an environment
+    will obtain a new Gurobi license token. If you are operating in a setting
+    where the number of concurrent Gurobi tokens is limited, you may want to
+    construct a single environment ahead of time and share it among all the
+    models solved by your program.
+
+    The `silent` option temporarily redirects the standard output stream
+    while constructing the environment. This may be useful in preventing
+    Gurobi from printing messages to the screen every time an environment
+    is constructed.
+    """
+    function Env(silent::Bool=false)
         a = Array{Ptr{Void}}(1)
-        ret = @grb_ccall(loadenv, Cint, (Ptr{Ptr{Void}}, Ptr{UInt8}), 
-            a, C_NULL)
+        if silent
+            _stdout = STDOUT
+            stdout_rd, stdout_wr = redirect_stdout()
+            ret = try
+                @grb_ccall(loadenv, Cint, (Ptr{Ptr{Void}}, Ptr{UInt8}),
+                    a, C_NULL)
+            finally
+                redirect_stdout(_stdout)
+                close(stdout_rd)
+                close(stdout_wr)
+            end
+        else
+            ret = @grb_ccall(loadenv, Cint, (Ptr{Ptr{Void}}, Ptr{UInt8}),
+                a, C_NULL)
+        end
+
         if ret != 0
             if ret == 10009
                 error("Invalid Gurobi license")
@@ -45,7 +74,7 @@ end
 type GurobiError
     code::Int
     msg::String
-    
+
     function GurobiError(env::Env, code::Integer)
         new(convert(Int, code), get_error_msg(env))
     end

--- a/src/grb_env.jl
+++ b/src/grb_env.jl
@@ -5,7 +5,7 @@ type Env
     ptr_env::Ptr{Void}
 
     """
-        Env(silent::Bool=false)
+        Env(;silent::Bool=false)
 
     Construct a Gurobi environment. The environment maintains parameters of the
     Gurobi solver and its license. In particular, constructing an environment
@@ -19,7 +19,7 @@ type Env
     Gurobi from printing messages to the screen every time an environment
     is constructed.
     """
-    function Env(silent::Bool=false)
+    function Env(;silent::Bool=false)
         a = Array{Ptr{Void}}(1)
         if silent
             _stdout = STDOUT

--- a/test/env.jl
+++ b/test/env.jl
@@ -27,4 +27,20 @@ using Gurobi, MathProgBase, Base.Test
     # Check that env is finalized with model when not supplied manually
     finalize(m3.inner)
     @test !Gurobi.is_valid(m3.inner.env)
+
+    # Test creating environment silently
+    # To actualy test this, we need to redirect STDOUT ourselves,
+    # run the environment constructor, and verify that nothing was
+    # printed to the captured stdout.
+    _stdout = STDOUT
+    try
+        rd, wr = redirect_stdout()
+        Gurobi.Env(silent=true)
+        redirect_stdout(_stdout)
+        @test isempty(readavailable(rd))
+    finally
+        redirect_stdout(_stdout) # this will be done twice if there is no error in the try block, but that's fine
+        close(rd)
+        close(wr)
+    end
 end


### PR DESCRIPTION
Gurobi 7.5 introduced an academic license notification which prints on every single environment construction (see [this post](https://groups.google.com/forum/#!searchin/gurobi/Academic$20license$20for$20non-commercial$20use|sort:date/gurobi/O7Kht25-OIA/ipRHU_cyAQAJ)). Since my stdout is now filled with Gurobi messages, I figured it would be nice to be able to turn them off. 

This PR just adds a `silent` flag to the `Env()` constructor that temporarily redirects stdout while constructing the environment. 

I also added a test to at least verify that the flag does not cause an error when set to `true`. My initial attempts at actually testing that nothing is printed led down a dark rabbit hole of libuv streams which did not seem worth the effort. If you *do* want a test of the behavior, then I'd suggest making https://github.com/Ismael-VC/Suppressor.jl a test dependency and using its `@capture_stdout`. Just let me know if you want that. 