### PR TITLE
Process cutoff status from inner model.

### DIFF
--- a/src/GurobiSolverInterface.jl
+++ b/src/GurobiSolverInterface.jl
@@ -440,6 +440,8 @@ function status(m::GurobiMathProgModel)
     return :InProgress
   elseif s == :user_obj_limit
     return :UserObjLimit
+  elseif s == :cutoff
+    return :Cutoff
   else
     error("Unrecognized solution status: $s")
   end


### PR DESCRIPTION
Gurobi ([since at least v6.0](http://www.gurobi.com/documentation/6.0/refman/optimization_status_codes.html#sec:StatusCodes)) has returned a `CUTOFF` status code. 

This is correctly processed in [`grb_solve.jl`](https://github.com/JuliaOpt/Gurobi.jl/blob/master/src/grb_solve.jl#L28-L60), but is not recognized as a solution status in [`GurobiSolverInterface.jl`](https://github.com/JuliaOpt/Gurobi.jl/blob/master/src/GurobiSolverInterface.jl#L420-L446). 

This results in a spurious error (as shown in the logs below) when the user passes a solver with a cutoff option `GurobiSolver(Cutoff = 10)`. An example (partial) log is shown below.

```
...
Root relaxation: objective 0.000000e+00, 243 iterations, 0.01 seconds

    Nodes    |    Current Node    |     Objective Bounds      |     Work
 Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time

     0     0    0.00000    0    6          -    0.00000      -     -    0s
Another try with MIP start
     0     0    0.00000    0   11          -    0.00000      -     -    0s
     0     0    0.00000    0   12          -    0.00000      -     -    0s
     0     0    0.00000    0   10          -    0.00000      -     -    0s
     0     0    0.00000    0   10          -    0.00000      -     -    0s
     0     0    0.00000    0   10          -    0.00000      -     -    0s
     0     0    0.00000    0   10          -    0.00000      -     -    0s
     0     0    0.00000    0   12          -    0.00000      -     -    0s
     0     0    0.00000    0   15          -    0.00000      -     -    0s
     0     0    0.00000    0   15          -    0.00000      -     -    0s
     0     0    0.00000    0   14          -    0.00000      -     -    0s
     0     0    0.00000    0   14          -    0.00000      -     -    0s
     0     2    0.00000    0   14          -    0.00000      -     -    0s
  4112   163     cutoff   27               -    8.11370      -  70.9    5s

Cutting planes:
  Gomory: 3
  Cover: 1
  MIR: 11
  Flow cover: 9

Explored 5707 nodes (405940 simplex iterations) in 6.55 seconds
Thread count was 8 (of 8 available processors)

Solution count 0
Pool objective bound 10

Model objective exceeds cutoff
Best objective -, best bound 1.000000000000e+01, gap -
Unrecognized solution status: cutoff

Stacktrace:
 [1] status(::Gurobi.GurobiMathProgModel) at /home/vtjeng/.julia/v0.6/Gurobi/src/GurobiSolverInterface.jl:385
 [2] #solve#116(::Bool, ::Bool, ::Bool, ::Array{Any,1}, ::Function, ::JuMP.Model) at /home/vtjeng/.julia/v0.6/JuMP/src/solvers.jl:176
 [3] solve(::JuMP.Model) at /home/vtjeng/.julia/v0.6/JuMP/src/solvers.jl:150
...
```