### PR TITLE
use Ref instead of Array when getting Gurobi parameters

### DIFF
--- a/src/grb_attrs.jl
+++ b/src/grb_attrs.jl
@@ -8,79 +8,79 @@
 
 function get_intattr(model::Model, name::String)
     @assert isascii(name)
-    a = Array{Cint}(1)
+    a = Ref{Cint}()
     ret = @grb_ccall(getintattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Ptr{Cint}),
+        (Ptr{Void}, Ptr{UInt8}, Ref{Cint}),
         model, name, a);
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
-    convert(Int, a[1])
+    Int(a[])
 end
 
 function get_dblattr(model::Model, name::String)
     @assert isascii(name)
-    a = Array{Float64}(1)
+    a = Ref{Float64}()
     ret = @grb_ccall(getdblattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Ptr{Float64}),
+        (Ptr{Void}, Ptr{UInt8}, Ref{Float64}),
         model, name, a);
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
-    a[1]::Float64
+    a[]
 end
 
 function get_strattr(model::Model, name::String)
     @assert isascii(name)
-    a = Array{Ptr{UInt8}}(1)
+    a = Ref{Ptr{UInt8}}()
     ret = @grb_ccall(getstrattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Ptr{Ptr{UInt8}}),
+        (Ptr{Void}, Ptr{UInt8}, Ref{Ptr{UInt8}}),
         model, name, a)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
-    unsafe_string(a[1])
+    unsafe_string(a[])
 end
 
 # array element
 
 function get_intattrelement(model::Gurobi.Model, name::String, element::Int)
     @assert isascii(name)
-    a = Array{Cint}(1)
+    a = Ref{Cint}()
     ret = @grb_ccall(getintattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Cint}),
+        (Ptr{Void}, Ptr{UInt8}, Cint, Ref{Cint}),
         model, name, element - 1, a
     )
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
-    convert(Int, a[1])
+    Int(a[])
 end
 
 function get_dblattrelement(model::Gurobi.Model, name::String, element::Int)
     @assert isascii(name)
-    a = Array{Float64}(1)
+    a = Ref{Float64}()
     ret = @grb_ccall(getdblattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Float64}),
+        (Ptr{Void}, Ptr{UInt8}, Cint, Ref{Float64}),
         model, name, element - 1, a
     )
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
-    a[1]::Float64
+    a[]
 end
 
 function get_charattrelement(model::Gurobi.Model, name::String, element::Int)
     @assert isascii(name)
-    a = Array{Cchar}(1)
+    a = Ref{Cchar}()
     ret = @grb_ccall(getcharattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Cchar}),
+        (Ptr{Void}, Ptr{UInt8}, Cint, Ref{Cchar}),
         model, name, element - 1, a
     )
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
-    convert(Char, a[1])
+    Char(a[])
 end
 
 # Note: in attrarray API, the start argument is one-based (following Julia convention)
@@ -108,7 +108,7 @@ function get_intattrlist!{I<:Integer}(r::Array{Cint}, model::Model, name::String
     nothing
 end
 
-function get_intattrlist{I<:Integer}(model::Model, name::String, inds::Vector{I}) 
+function get_intattrlist{I<:Integer}(model::Model, name::String, inds::Vector{I})
     r = Array{Cint}(length(inds))
     get_intattrlist!(r::Array{Cint}, model::Model, name::String, inds)
     return r

--- a/test/test_grb_attrs.jl
+++ b/test/test_grb_attrs.jl
@@ -26,6 +26,10 @@ using Gurobi, Base.Test
     add_constr!(model, [1., 2., 1.], '<', 15.)
 
     update_model!(model)
+    @test Gurobi.get_intattr(model, "NumVars") == 3
+    @test Gurobi.get_dblattr(model, "ObjCon") == 0.0
+    @test Gurobi.get_strattr(model, "ModelName") == "mip_01"
+
 
     @test Gurobi.get_dblattrelement(model, "UB", 1) == 5.0
     @test Gurobi.get_charattrelement(model, "Sense", 1) == '<'


### PR DESCRIPTION
Allocating an entire `Array` is quite expensive and not actually necessary just to be able to pass a reference to a C function. Using a `Ref` saves 80 bytes of memory on Julia v0.6.3, and I think Julia v0.7 should be able to eliminate the memory allocation entirely. 

Before: 

```julia
julia> @btime Gurobi.get_intattr_old(m, $("NumQNZs"))
  80.248 ns (1 allocation: 96 bytes)
0
```

After: 

```julia
julia> @btime Gurobi.get_intattr(m, $("NumQNZs"))
  70.103 ns (1 allocation: 16 bytes)
0
```
