### PR TITLE
Improve performance of coefficient modification

### DIFF
--- a/src/grb_common.jl
+++ b/src/grb_common.jl
@@ -19,9 +19,9 @@ ivec(v::IVec) = v
 fvec(v::FVec) = v
 cvec(v::CVec) = v
 
-ivec(v::Vector) = convert(IVec, v)
-fvec(v::Vector) = convert(FVec, v)
-cvec(v::Vector) = convert(CVec, v)
+ivec(v::AbstractVector) = convert(IVec, v)
+fvec(v::AbstractVector) = convert(FVec, v)
+cvec(v::AbstractVector) = convert(CVec, v)
 
 ivec(s::Integer) = Cint[s]
 

--- a/test/MathProgBase/large_coefficients.jl
+++ b/test/MathProgBase/large_coefficients.jl
@@ -6,7 +6,7 @@ using Gurobi, MathProgBase, Base.Test
         # Min   1.1e100x
         #       x >= 1
         m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [1],[Inf], [1.1e100], Float64[], Float64[], :Min)
+        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [1],[Inf], [1.1e100], Float64[], Float64[], :Min)
         MathProgBase.optimize!(m)
         @test MathProgBase.getsolution(m) == [1.0]
         @test MathProgBase.getobjval(m) == 1e100
@@ -14,7 +14,7 @@ using Gurobi, MathProgBase, Base.Test
         # Max   -1.1e100x
         #       x >= 1
         m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [1],[Inf], [-1.1e100], Float64[], Float64[], :Max)
+        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [1],[Inf], [-1.1e100], Float64[], Float64[], :Max)
         MathProgBase.optimize!(m)
         @test MathProgBase.getsolution(m) == [1.0]
         @test MathProgBase.getobjval(m) == -1e100
@@ -24,28 +24,28 @@ using Gurobi, MathProgBase, Base.Test
         # Min   x
         #       x >= 1.1e30
         m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [1.1e30],[Inf], [1], Float64[], Float64[], :Min)
+        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [1.1e30],[Inf], [1], Float64[], Float64[], :Min)
         MathProgBase.optimize!(m)
         @test MathProgBase.status(m) == :Infeasible
 
         # Max   x
         #       x <= -1.1e30
         m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [-Inf],[-1.1e30], [1], Float64[], Float64[], :Max)
+        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [-Inf],[-1.1e30], [1], Float64[], Float64[], :Max)
         MathProgBase.optimize!(m)
         @test MathProgBase.status(m) == :Infeasible
 
         # Min   x
         #       x >= -1.1e30
         m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [-1.1e30],[Inf], [1], Float64[], Float64[], :Min)
+        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [-1.1e30],[Inf], [1], Float64[], Float64[], :Min)
         MathProgBase.optimize!(m)
         @test MathProgBase.status(m) == :Unbounded
 
         # Max   x
         #       x <= 1.1e30
         m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array(Float64, (0, 1)), [-Inf],[1.1e30], [1], Float64[], Float64[], :Max)
+        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [-Inf],[1.1e30], [1], Float64[], Float64[], :Max)
         MathProgBase.optimize!(m)
         @test MathProgBase.status(m) == :Unbounded
 

--- a/test/constraint_modification.jl
+++ b/test/constraint_modification.jl
@@ -13,6 +13,11 @@ using Gurobi: getcoeff
     model = gurobi_model(Gurobi.Env(); f=f, A=A, b=b)
 
     @test getcoeff(model, 1, 1) == 1.0
+
+    # Verify that we can pass any kind of `::Integer` to `getcoeff`
+    @test getcoeff(model, 1, Int8(1)) == 1.0
+    @test getcoeff(model, UInt32(1), UInt32(1)) == 1.0
+
     @test getcoeff(model, 1, 2) == 2.0
     @test getcoeff(model, 2, 1) == 3.0
     @test getcoeff(model, 2, 2) == 0.0
@@ -24,6 +29,8 @@ using Gurobi: getcoeff
     update_model!(model)
     @test getcoeff(model, 2, 1) == 1.5
 
+    # Verify that we are automatically converting the scalars to
+    # Cint and Float64 as necessary
     chg_coeffs!(model, Int8(2), Int128(1), Float32(2.0))
     update_model!(model)
     @test getcoeff(model, 2, 1) == 2.0

--- a/test/constraint_modification.jl
+++ b/test/constraint_modification.jl
@@ -1,0 +1,44 @@
+using Gurobi
+using Base.Test
+using Gurobi: getcoeff
+
+
+@testset "changing coefficients" begin
+    A = spzeros(2, 2)
+    A[1, 1] = 1.0
+    A[1, 2] = 2.0
+    A[2, 1] = 3.0
+    b = [0.1, 0.2]
+    f = [0.0, 0.0]
+    model = gurobi_model(Gurobi.Env(); f=f, A=A, b=b)
+
+    @test getcoeff(model, 1, 1) == 1.0
+    @test getcoeff(model, 1, 2) == 2.0
+    @test getcoeff(model, 2, 1) == 3.0
+    @test getcoeff(model, 2, 2) == 0.0
+
+    chg_coeffs!(model, 2, 1, 1.5)
+    # before updating the model, we still get the old coefficient value
+    @test getcoeff(model, 2, 1) == 3.0
+    # after updating the model, we see the new coefficient value
+    update_model!(model)
+    @test getcoeff(model, 2, 1) == 1.5
+
+    chg_coeffs!(model, Int8(2), Int128(1), Float32(2.0))
+    update_model!(model)
+    @test getcoeff(model, 2, 1) == 2.0
+
+    chg_coeffs!(model, [1, 2], [1, 1], [5.0, 6.5])
+    update_model!(model)
+    @test getcoeff(model, 1, 1) == 5.0
+    @test getcoeff(model, 2, 1) == 6.5
+    @test getcoeff(model, 1, 2) == 2.0
+    @test getcoeff(model, 2, 2) == 0.0
+
+    chg_coeffs!(model, Int8[1, 2], Int8[1, 1], Float32[1.0, 2.0])
+    update_model!(model)
+    @test getcoeff(model, 1, 1) == 1.0
+    @test getcoeff(model, 2, 1) == 2.0
+    @test getcoeff(model, 1, 2) == 2.0
+    @test getcoeff(model, 2, 2) == 0.0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,3 +31,5 @@ end
 @testset "MathOptInterface Tests" begin
     evalfile("MOIWrapper.jl")
 end
+
+include("constraint_modification.jl")


### PR DESCRIPTION
`chg_coeffs` when called with scalar indices was previously allocating a length-1 vector of indices and values, which is pretty inefficient. This PR changes that to using Refs, which are quite a bit cheaper. `getcoeff` was also unnecessarily allocating a vector for its return type, so I changed that as well. I deprecated the `getcoeff!` method which operated on that unnecessary vector. 

I also added some unit tests to verify the basics of getting and setting coefficients. 

Setting a single coefficient goes from `214.000 ns (5 allocations: 480 bytes)` to `89.000 ns (3 allocations: 48 bytes)` after this PR. Performance should improve even more in v0.7, since the Refs won't need to be heap-allocated. 

I also fixed some remaining deprecation warnings in the MPB tests. 

@odow this is a PR against your branch in #125 . Let me know if I should open it against `master` instead. 
