### PR TITLE
Pass constant objective terms all the way to the solver

### DIFF
--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -251,6 +251,16 @@ function LQOI.set_linear_objective!(instance::GurobiOptimizer, columns::Vector{I
     update_model!(instance.inner)
 end
 
+function LQOI.set_constant_objective!(instance::GurobiOptimizer, value::Real)
+    set_dblattr!(instance.inner, "ObjCon", value)
+    if num_vars(instance.inner) > 0
+        # Work-around for https://github.com/JuliaOpt/LinQuadOptInterface.jl/pull/44#issuecomment-409373755
+        set_dblattrarray!(instance.inner, "Obj", 1, 1,
+            get_dblattrarray(instance.inner, "Obj", 1, 1))
+    end
+    update_model!(instance.inner)
+end
+
 function LQOI.change_objective_sense!(instance::GurobiOptimizer, symbol)
     if symbol == :min
         set_sense!(instance.inner, :minimize)
@@ -262,6 +272,10 @@ end
 
 function LQOI.get_linear_objective!(instance::GurobiOptimizer, x)
     copy!(x, get_dblattrarray(instance.inner, "Obj", 1, num_vars(instance.inner)))
+end
+
+function LQOI.get_constant_objective(instance::GurobiOptimizer)
+    get_dblattr(instance.inner, "ObjCon")
 end
 
 function LQOI.get_objectivesense(instance::GurobiOptimizer)

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -240,9 +240,4 @@ end
     MOI.modify!(m, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarConstantChange(3.0))
     @test MOI.get(m, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()).constant == 3.0
     @test Gurobi.get_dblattr(m.inner, "ObjCon") == 3.0
-
-    MOI.set!(m, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
-        MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm{Float64}[], MOI.ScalarQuadraticTerm{Float64}[], -2.5))
-    @test MOI.get(m, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}()).constant == -2.5
-    @test Gurobi.get_dblattr(m.inner, "ObjCon") == -2.5
 end

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -228,3 +228,21 @@ end
     # But we have no dual status:
     @test MOI.get(m, MOI.DualStatus()) == MOI.UnknownResultStatus
 end
+
+@testset "Constant objective (issue #111)" begin
+    m = GurobiOptimizer()
+    x = MOI.addvariable!(m)
+    MOI.set!(m, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[], 2.0))
+    @test MOI.get(m, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()).constant == 2.0
+    @test Gurobi.get_dblattr(m.inner, "ObjCon") == 2.0
+
+    MOI.modify!(m, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarConstantChange(3.0))
+    @test MOI.get(m, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()).constant == 3.0
+    @test Gurobi.get_dblattr(m.inner, "ObjCon") == 3.0
+
+    MOI.set!(m, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm{Float64}[], MOI.ScalarQuadraticTerm{Float64}[], -2.5))
+    @test MOI.get(m, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}()).constant == -2.5
+    @test Gurobi.get_dblattr(m.inner, "ObjCon") == -2.5
+end


### PR DESCRIPTION
Fixes #111 (for the MOI interface). Requires https://github.com/JuliaOpt/LinQuadOptInterface.jl/pull/44

This currently contains a really gross workaround for the issues discussed in https://github.com/JuliaOpt/LinQuadOptInterface.jl/pull/44#issuecomment-409373755 . I'm happy to wait until we have a better solution for that before merging; I just wanted to get this PR opened so I won't forget about the changes. 