### PR TITLE
RFC: updates for MOI 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 MathProgBase 0.5 0.8
 Compat 0.18
-LinQuadOptInterface 0.2 0.3
+LinQuadOptInterface 0.3 0.4

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,1 +1,2 @@
 deps.jl
+build.log

--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -8,11 +8,13 @@ module Gurobi
         error("Gurobi not properly installed. Please run Pkg.build(\"Gurobi\")")
     end
 
+    using Compat
+    using Compat.SparseArrays
+    using Compat.LinearAlgebra
+
     ### imports
 
     import Base.show, Base.copy, Base.read
-
-    using Compat
 
     # Standard LP interface
     importall MathProgBase.SolverInterface

--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -45,35 +45,44 @@ end
 
 LQOI.LinearQuadraticModel(::Type{GurobiOptimizer},env) = Model(env::Env,"defaultname")
 
+"""
+    GurobiOptimizer(;kwargs...)
+
+Create a new GurobiOptimizer object.
+
+Note that we set the parameter `InfUnbdInfo` to `1` rather than the default of
+`0` so that we can query infeasibility certificates. Users are, however, free to
+overide this as follows `GurobiOptimizer(InfUndbInfo=0)`.
+"""
 function GurobiOptimizer(;kwargs...)
-    env = Env()
-    m = GurobiOptimizer(nothing)
-    m.env = env
-    m.params = Dict{String,Any}()
-    MOI.empty!(m)
-    for (name,value) in kwargs
-        m.params[string(name)] = value
-        setparam!(m.inner, string(name), value)
+    model = GurobiOptimizer(nothing)
+    model.env = Env()
+    model.params = Dict{String,Any}()
+    MOI.empty!(model)
+    for (name, value) in kwargs
+        model.params[string(name)] = value
+        setparam!(model.inner, string(name), value)
     end
-    return m
+    return model
 end
 
-function MOI.empty!(m::GurobiOptimizer)
-    MOI.empty!(m,m.env)
-    for (name,value) in m.params
-        setparam!(m.inner, name, value)
+function MOI.empty!(model::GurobiOptimizer)
+    MOI.empty!(model, model.env)
+    setparam!(model.inner, "InfUnbdInfo", 1)
+    for (name, value) in model.params
+        setparam!(model.inner, name, value)
     end
 end
 
-LQOI.supported_constraints(s::GurobiOptimizer) = SUPPORTED_CONSTRAINTS
-LQOI.supported_objectives(s::GurobiOptimizer)  = SUPPORTED_OBJECTIVES
+LQOI.supported_constraints(::GurobiOptimizer) = SUPPORTED_CONSTRAINTS
+LQOI.supported_objectives(::GurobiOptimizer)  = SUPPORTED_OBJECTIVES
 
-LQOI.backend_type(m::GurobiOptimizer, ::MOI.EqualTo{Float64})     = Cchar('=')
-LQOI.backend_type(m::GurobiOptimizer, ::MOI.LessThan{Float64})    = Cchar('<')
-LQOI.backend_type(m::GurobiOptimizer, ::MOI.GreaterThan{Float64}) = Cchar('>')
-LQOI.backend_type(m::GurobiOptimizer, ::MOI.Zeros)                = Cchar('=')
-LQOI.backend_type(m::GurobiOptimizer, ::MOI.Nonpositives)         = Cchar('<')
-LQOI.backend_type(m::GurobiOptimizer, ::MOI.Nonnegatives)         = Cchar('>')
+LQOI.backend_type(::GurobiOptimizer, ::MOI.EqualTo{Float64})     = Cchar('=')
+LQOI.backend_type(::GurobiOptimizer, ::MOI.LessThan{Float64})    = Cchar('<')
+LQOI.backend_type(::GurobiOptimizer, ::MOI.GreaterThan{Float64}) = Cchar('>')
+LQOI.backend_type(::GurobiOptimizer, ::MOI.Zeros)                = Cchar('=')
+LQOI.backend_type(::GurobiOptimizer, ::MOI.Nonpositives)         = Cchar('<')
+LQOI.backend_type(::GurobiOptimizer, ::MOI.Nonnegatives)         = Cchar('>')
 
 function LQOI.change_variable_bounds!(model::GurobiOptimizer,
           columns::Vector{Int}, new_bounds::Vector{Float64},

--- a/src/MOIWrapper.jl
+++ b/src/MOIWrapper.jl
@@ -436,31 +436,35 @@ function LQOI.get_quadratic_dual_solution!(model::Optimizer, place)
 end
 
 LQOI.get_objective_value(model::Optimizer) = get_objval(model.inner)
-LQOI.get_objective_bound(model::Optimizer) = get_objval(model.inner)
+
+function LQOI.get_objective_bound(model::Optimizer)
+    return get_objbound(model.inner)
+end
 
 function LQOI.get_relative_mip_gap(model::Optimizer)
-    L = get_objval(model.inner)
-    U = get_objbound(model.inner)
-    return abs(U-L)/U
+    value = LQOI.get_objective_value(model)
+    bound = LQOI.get_objective_bound(model)
+    return abs(value - bound) / abs(bound)
 end
 
 function LQOI.get_iteration_count(instance::Optimizer)
-    get_iter_count(instance.inner)
+    return get_iter_count(instance.inner)
 end
 
 function LQOI.get_barrier_iterations(instance::Optimizer)
-    get_barrier_iter_count(instance.inner)
+    return get_barrier_iter_count(instance.inner)
 end
 
 function LQOI.get_node_count(instance::Optimizer)
-    get_node_count(instance.inner)
+    return get_node_count(instance.inner)
 end
 
 function LQOI.get_farkas_dual!(instance::Optimizer, place)
     get_dblattrarray!(place, instance.inner, "FarkasDual", 1)
-    scale!(place, -1.0)
+    place .*= -1.0
 end
 
+# TODO(odow): remove try/catch
 function hasdualray(model::Optimizer)
     try
         get_dblattrarray(model.inner, "FarkasDual", 1, num_constrs(model.inner))
@@ -470,8 +474,11 @@ function hasdualray(model::Optimizer)
     end
 end
 
-LQOI.get_unbounded_ray!(model::Optimizer, place) = get_dblattrarray!(place, model.inner, "UnbdRay", 1)
+function LQOI.get_unbounded_ray!(model::Optimizer, place)
+    get_dblattrarray!(place, model.inner, "UnbdRay", 1)
+end
 
+# TODO(odow): remove try/catch
 function hasprimalray(model::Optimizer)
     try
         get_dblattrarray(model.inner, "UnbdRay", 1, num_vars(model.inner))
@@ -482,7 +489,6 @@ function hasprimalray(model::Optimizer)
 end
 
 MOI.free!(m::Optimizer) = free_model(m.inner)
-
 
 # ==============================================================================
 #    Callbacks in Gurobi

--- a/src/grb_attrs.jl
+++ b/src/grb_attrs.jl
@@ -10,7 +10,7 @@ function get_intattr(model::Model, name::String)
     @assert isascii(name)
     a = Ref{Cint}()
     ret = @grb_ccall(getintattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Ref{Cint}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Ref{Cint}),
         model, name, a);
     if ret != 0
         throw(GurobiError(model.env, ret))
@@ -22,7 +22,7 @@ function get_dblattr(model::Model, name::String)
     @assert isascii(name)
     a = Ref{Float64}()
     ret = @grb_ccall(getdblattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Ref{Float64}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Ref{Float64}),
         model, name, a);
     if ret != 0
         throw(GurobiError(model.env, ret))
@@ -34,7 +34,7 @@ function get_strattr(model::Model, name::String)
     @assert isascii(name)
     a = Ref{Ptr{UInt8}}()
     ret = @grb_ccall(getstrattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Ref{Ptr{UInt8}}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Ref{Ptr{UInt8}}),
         model, name, a)
     if ret != 0
         throw(GurobiError(model.env, ret))
@@ -48,7 +48,7 @@ function get_intattrelement(model::Gurobi.Model, name::String, element::Int)
     @assert isascii(name)
     a = Ref{Cint}()
     ret = @grb_ccall(getintattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ref{Cint}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ref{Cint}),
         model, name, element - 1, a
     )
     if ret != 0
@@ -61,7 +61,7 @@ function get_dblattrelement(model::Gurobi.Model, name::String, element::Int)
     @assert isascii(name)
     a = Ref{Float64}()
     ret = @grb_ccall(getdblattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ref{Float64}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ref{Float64}),
         model, name, element - 1, a
     )
     if ret != 0
@@ -74,7 +74,7 @@ function get_charattrelement(model::Gurobi.Model, name::String, element::Int)
     @assert isascii(name)
     a = Ref{Cchar}()
     ret = @grb_ccall(getcharattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ref{Cchar}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ref{Cchar}),
         model, name, element - 1, a
     )
     if ret != 0
@@ -88,7 +88,7 @@ end
 function get_intattrarray!(r::Array{Cint}, model::Model, name::String, start::Integer)
     @assert isascii(name)
     ret = @grb_ccall(getintattrarray, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Cint}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint, Ptr{Cint}),
         model, name, start - 1, length(r), r)
     if ret != 0
         throw(GurobiError(model.env, ret))
@@ -100,8 +100,8 @@ function get_intattrlist!(r::Array{Cint}, model::Model, name::String, inds::Vect
     @assert isascii(name)
     @assert length(r) == length(inds)
     ret = @grb_ccall(getintattrlist, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cint}),
-        model, name, Cint(length(inds)), ivec(inds - 1), r)
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cint}),
+        model, name, Cint(length(inds)), ivec(inds .- 1), r)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -109,7 +109,7 @@ function get_intattrlist!(r::Array{Cint}, model::Model, name::String, inds::Vect
 end
 
 function get_intattrlist(model::Model, name::String, inds::Vector{I}) where I<:Integer
-    r = Array{Cint}(length(inds))
+    r = Array{Cint}(undef, length(inds))
     get_intattrlist!(r::Array{Cint}, model::Model, name::String, inds)
     return r
 end
@@ -122,7 +122,7 @@ end
 function get_dblattrarray!(r::Array{Float64}, model::Model, name::String, start::Integer)
     @assert isascii(name)
     ret = @grb_ccall(getdblattrarray, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Float64}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint, Ptr{Float64}),
         model, name, start - 1, length(r), r)
     if ret != 0
         throw(GurobiError(model.env, ret))
@@ -134,8 +134,8 @@ function get_dblattrlist!(r::Array{Float64}, model::Model, name::String, inds::V
     @assert isascii(name)
     @assert length(r) == length(inds)
     ret = @grb_ccall(getdblattrlist, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Float64}),
-        model, name, Cint(length(inds)), ivec(inds - 1), r)
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Float64}),
+        model, name, Cint(length(inds)), ivec(inds .- 1), r)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -143,20 +143,20 @@ function get_dblattrlist!(r::Array{Float64}, model::Model, name::String, inds::V
 end
 
 function get_dblattrlist(model::Model, name::String, inds::Vector{I}) where I<:Integer
-    r = Array{Float64}(length(inds))
+    r = Array{Float64}(undef, length(inds))
     get_dblattrlist!(r::Array{Float64}, model::Model, name::String, inds)
     return r
 end
 
 function get_dblattrarray(model::Model, name::String, start::Integer, len::Integer)
     @assert isascii(name)
-    get_dblattrarray!(Array{Float64}(len), model, name, start)
+    get_dblattrarray!(Array{Float64}(undef, len), model, name, start)
 end
 
 function get_charattrarray!(r::Array{Cchar}, model::Model, name::String, start::Integer)
     @assert isascii(name)
     ret = @grb_ccall(getcharattrarray, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Cchar}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint, Ptr{Cchar}),
         model, name, start - 1, length(r), r)
     if ret != 0
         throw(GurobiError(model.env, ret))
@@ -168,8 +168,8 @@ function get_charattrlist!(r::Array{Cchar}, model::Model, name::String, inds::Ve
     @assert isascii(name)
     @assert length(r) == length(inds)
     ret = @grb_ccall(getcharattrlist, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cchar}),
-        model, name, Cint(length(inds)), ivec(inds - 1), r)
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cchar}),
+        model, name, Cint(length(inds)), ivec(inds .- 1), r)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -177,25 +177,25 @@ function get_charattrlist!(r::Array{Cchar}, model::Model, name::String, inds::Ve
 end
 
 function get_charattrlist(model::Model, name::String, inds::Vector{I}) where I<:Integer
-    r = Array{Cchar}(length(inds))
+    r = Array{Cchar}(undef, length(inds))
     get_charattrlist!(r::Array{Cchar}, model::Model, name::String, inds)
     return r
 end
 
 function get_charattrarray(model::Model, name::String, start::Integer, len::Integer)
     @assert isascii(name)
-    get_charattrarray!(Array{Cchar}(len), model, name, start)
+    get_charattrarray!(Array{Cchar}(undef, len), model, name, start)
 end
 
 function get_strattrarray(model::Model, name::String, start::Integer, len::Integer)
     @assert isascii(name)
-    get_strattrarray!(Array{Ptr{UInt8}}(len), model, name, start)
+    get_strattrarray!(Array{Ptr{UInt8}}(undef, len), model, name, start)
 end
 
 function get_strattrarray!(r::Array{Ptr{UInt8}}, model::Model, name::String, start::Integer)
     @assert isascii(name)
     ret = @grb_ccall(getstrattrarray, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Ptr{UInt8}}),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint, Ptr{Ptr{UInt8}}),
         model, name, start - 1, length(r), r)
     if ret != 0
         throw(GurobiError(model.env, ret))
@@ -208,7 +208,7 @@ end
 function set_intattr!(model::Model, name::String, v::Integer)
     @assert isascii(name)
     ret = @grb_ccall(setintattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint), model, name, v)
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint), model, name, v)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -218,7 +218,7 @@ end
 function set_dblattr!(model::Model, name::String, v::Real)
     @assert isascii(name)
     ret = @grb_ccall(setdblattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Float64), model, name, v)
+        (Ptr{Cvoid}, Ptr{UInt8}, Float64), model, name, v)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -229,7 +229,7 @@ function set_strattr!(model::Model, name::String, v::String)
     @assert isascii(name)
     @assert isascii(v)
     ret = @grb_ccall(setstrattr, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}), model, name, v)
+        (Ptr{Cvoid}, Ptr{UInt8}, Ptr{UInt8}), model, name, v)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -241,7 +241,7 @@ end
 function set_intattrelement!(model::Gurobi.Model, name::String, element::Int, v::Integer)
     @assert isascii(name)
     ret = @grb_ccall(setintattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cint),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint),
         model, name, element - 1, v
     )
     if ret != 0
@@ -253,7 +253,7 @@ end
 function set_dblattrelement!(model::Gurobi.Model, name::String, element::Int, v::Real)
     @assert isascii(name)
     ret = @grb_ccall(setdblattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Float64),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Float64),
         model, name, element - 1, v
     )
     if ret != 0
@@ -265,7 +265,7 @@ end
 function set_charattrelement!(model::Gurobi.Model, name::String, element::Int, v::Char)
     @assert isascii(name)
     ret = @grb_ccall(setcharattrelement, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cchar),
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cchar),
         model, name, element - 1, v
     )
     if ret != 0
@@ -280,7 +280,7 @@ function set_intattrarray!(model::Model, name::String, start::Integer, len::Inte
     @assert isascii(name)
     values = convert(Vector{Cint},values)
     ret = @grb_ccall(setintattrarray, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Cint}), model, name, start-1, len, ivec(values))
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint, Ptr{Cint}), model, name, start-1, len, ivec(values))
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -291,7 +291,7 @@ function set_intattrlist!(model::Model, name::String, inds::Vector, values::Vect
     @assert isascii(name)
     @assert length(inds) == length(values)
     ret = @grb_ccall(setintattrlist, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cint}), model, name, Cint(length(inds)), ivec(inds-1), ivec(values))
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cint}), model, name, Cint(length(inds)), ivec(inds.-1), ivec(values))
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -302,7 +302,7 @@ function set_dblattrarray!(model::Model, name::String, start::Integer, len::Inte
     @assert isascii(name)
     values = convert(Vector{Float64},values)
     ret = @grb_ccall(setdblattrarray, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Float64}), model, name, start-1, len, fvec(values))
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint, Ptr{Float64}), model, name, start-1, len, fvec(values))
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -313,7 +313,7 @@ function set_dblattrlist!(model::Model, name::String, inds::Vector, values::Vect
     @assert isascii(name)
     @assert length(inds) == length(values)
     ret = @grb_ccall(setdblattrlist, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Float64}), model, name, Cint(length(inds)), ivec(inds-1), fvec(values))
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Float64}), model, name, Cint(length(inds)), ivec(inds.-1), fvec(values))
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -324,7 +324,7 @@ function set_charattrarray!(model::Model, name::String, start::Integer, len::Int
     @assert isascii(name)
     values = convert(Vector{Cchar},values)
     ret = @grb_ccall(setcharattrarray, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Cchar}), model, name, start-1, len, cvec(values))
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint, Ptr{Cchar}), model, name, start-1, len, cvec(values))
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -335,7 +335,7 @@ function set_charattrlist!(model::Model, name::String, inds::Vector, values::Vec
     @assert isascii(name)
     @assert length(inds) == length(values)
     ret = @grb_ccall(setcharattrlist, Cint,
-        (Ptr{Void}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cchar}), model, name, Cint(length(inds)), ivec(inds-1), cvec(values))
+        (Ptr{Cvoid}, Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cchar}), model, name, Cint(length(inds)), ivec(inds.-1), cvec(values))
     if ret != 0
         throw(GurobiError(model.env, ret))
     end

--- a/src/grb_env.jl
+++ b/src/grb_env.jl
@@ -2,11 +2,11 @@
 
 
 mutable struct Env
-    ptr_env::Ptr{Void}
-    
+    ptr_env::Ptr{Cvoid}
+
     function Env()
-        a = Array{Ptr{Void}}(1)
-        ret = @grb_ccall(loadenv, Cint, (Ptr{Ptr{Void}}, Ptr{UInt8}), 
+        a = Ref{Ptr{Cvoid}}()
+        ret = @grb_ccall(loadenv, Cint, (Ptr{Ptr{Cvoid}}, Ptr{UInt8}),
             a, C_NULL)
         if ret != 0
             if ret == 10009
@@ -15,13 +15,13 @@ mutable struct Env
                 error("Failed to create environment (error $ret).")
             end
         end
-        env = new(a[1])
+        env = new(a[])
         # finalizer(env, free_env)  ## temporary disable: which tends to sometimes caused warnings
         env
     end
 end
 
-Base.unsafe_convert(ty::Type{Ptr{Void}}, env::Env) = env.ptr_env::Ptr{Void}
+Base.unsafe_convert(ty::Type{Ptr{Cvoid}}, env::Env) = env.ptr_env::Ptr{Cvoid}
 
 function is_valid(env::Env)
     env.ptr_env != C_NULL
@@ -29,14 +29,14 @@ end
 
 function free_env(env::Env)
     if env.ptr_env != C_NULL
-        @grb_ccall(freeenv, Void, (Ptr{Void},), env.ptr_env)
+        @grb_ccall(freeenv, Nothing, (Ptr{Cvoid},), env.ptr_env)
         env.ptr_env = C_NULL
     end
 end
 
 function get_error_msg(env::Env)
     @assert env.ptr_env != C_NULL
-    sz = @grb_ccall(geterrormsg, Ptr{UInt8}, (Ptr{Void},), env.ptr_env)
+    sz = @grb_ccall(geterrormsg, Ptr{UInt8}, (Ptr{Cvoid},), env.ptr_env)
     unsafe_string(sz)
 end
 
@@ -45,9 +45,8 @@ end
 mutable struct GurobiError
     code::Int
     msg::String
-    
+
     function GurobiError(env::Env, code::Integer)
         new(convert(Int, code), get_error_msg(env))
     end
 end
-

--- a/src/grb_params.jl
+++ b/src/grb_params.jl
@@ -156,30 +156,30 @@ const GRB_MAX_STRLEN = 512   # gurobi.c define this value as 512
 
 function get_int_param(env::Env, name::String)
     @assert isascii(name)
-    a = Array{Cint}(1)
-    ret = @grb_ccall(getintparam, Cint, (Ptr{Void}, Ptr{Cchar}, Ptr{Cint}),
+    a = Ref{Cint}()
+    ret = @grb_ccall(getintparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cint}),
         env, name, a)
     if ret != 0
         throw(GurobiError(env, ret))
     end
-    convert(Int, a[1])
+    convert(Int, a[])
 end
 
 function get_dbl_param(env::Env, name::String)
     @assert isascii(name)
-    a = Array{Float64}(1)
-    ret = @grb_ccall(getdblparam, Cint, (Ptr{Void}, Ptr{Cchar}, Ptr{Float64}),
+    a = Ref{Float64}()
+    ret = @grb_ccall(getdblparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Float64}),
         env, name, a)
     if ret != 0
         throw(GurobiError(env, ret))
     end
-    a[1]::Float64
+    a[]::Float64
 end
 
 function get_str_param(env::Env, name::String)
     @assert isascii(name)
-    buf = Array{Cchar}(GRB_MAX_STRLEN)
-    ret = @grb_ccall(getstrparam, Cint, (Ptr{Void}, Ptr{Cchar}, Ptr{Cchar}),
+    buf = Array{Cchar}(undef, GRB_MAX_STRLEN)
+    ret = @grb_ccall(getstrparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cchar}),
         env, name, buf)
     if ret != 0
         throw(GurobiError(env, ret))
@@ -190,7 +190,7 @@ end
 
 function set_int_param!(env::Env, name::String, v::Integer)
     @assert isascii(name)
-    ret = @grb_ccall(setintparam, Cint, (Ptr{Void}, Ptr{Cchar}, Cint),
+    ret = @grb_ccall(setintparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Cint),
         env, name, v)
     if ret != 0
         throw(GurobiError(env, ret))
@@ -199,7 +199,7 @@ end
 
 function set_dbl_param!(env::Env, name::String, v::Real)
     @assert isascii(name)
-    ret = @grb_ccall(setdblparam, Cint, (Ptr{Void}, Ptr{Cchar}, Float64),
+    ret = @grb_ccall(setdblparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Float64),
         env, name, v)
     if ret != 0
         throw(GurobiError(env, ret))
@@ -209,7 +209,7 @@ end
 function set_str_param!(env::Env, name::String, v::String)
     @assert isascii(name)
     @assert isascii(v)
-    ret = @grb_ccall(setstrparam, Cint, (Ptr{Void}, Ptr{Cchar}, Ptr{Cchar}),
+    ret = @grb_ccall(setstrparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cchar}),
         env, name, v)
     if ret != 0
         throw(GurobiError(env, ret))
@@ -221,38 +221,38 @@ end
 function get_int_param(m::Model, name::String)
 
     @assert isascii(name)
-    modenv = @grb_ccall(getenv, Ptr{Void}, (Ptr{Void},), m)
+    modenv = @grb_ccall(getenv, Ptr{Cvoid}, (Ptr{Cvoid},), m)
     @assert modenv != C_NULL
-    a = Array{Cint}(1)
-    ret = @grb_ccall(getintparam, Cint, (Ptr{Void}, Ptr{Cchar}, Ptr{Cint}),
+    a = Ref{Cint}()
+    ret = @grb_ccall(getintparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cint}),
         modenv, name, a)
     if ret != 0
         throw(GurobiError(Env(modenv), ret))
     end
-    convert(Int, a[1])
+    convert(Int, a[])
 end
 
 function get_dbl_param(m::Model, name::String)
 
     @assert isascii(name)
-    modenv = @grb_ccall(getenv, Ptr{Void}, (Ptr{Void},), m)
+    modenv = @grb_ccall(getenv, Ptr{Cvoid}, (Ptr{Cvoid},), m)
     @assert modenv != C_NULL
-    a = Array{Float64}(1)
-    ret = @grb_ccall(getdblparam, Cint, (Ptr{Void}, Ptr{Cchar}, Ptr{Float64}),
+    a = Ref{Float64}()
+    ret = @grb_ccall(getdblparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Float64}),
         modenv, name, a)
     if ret != 0
         throw(GurobiError(Env(modenv), ret))
     end
-    a[1]::Float64
+    a[]::Float64
 end
 
 function get_str_param(m::Model, name::String)
 
     @assert isascii(name)
-    modenv = @grb_ccall(getenv, Ptr{Void}, (Ptr{Void},), m)
+    modenv = @grb_ccall(getenv, Ptr{Cvoid}, (Ptr{Cvoid},), m)
     @assert modenv != C_NULL
-    buf = Array{Cchar}(GRB_MAX_STRLEN)
-    ret = @grb_ccall(getstrparam, Cint, (Ptr{Void}, Ptr{Cchar}, Ptr{Cchar}),
+    buf = Array{Cchar}(undef, GRB_MAX_STRLEN)
+    ret = @grb_ccall(getstrparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cchar}),
         modenv, name, buf)
     if ret != 0
         throw(GurobiError(Env(modenv), ret))
@@ -264,9 +264,9 @@ end
 function set_int_param!(m::Model, name::String, v::Integer)
 
     @assert isascii(name)
-    modenv = @grb_ccall(getenv, Ptr{Void}, (Ptr{Void},), m)
+    modenv = @grb_ccall(getenv, Ptr{Cvoid}, (Ptr{Cvoid},), m)
     @assert modenv != C_NULL
-    ret = @grb_ccall(setintparam, Cint, (Ptr{Void}, Ptr{Cchar}, Cint),
+    ret = @grb_ccall(setintparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Cint),
         modenv, name, v)
     if ret != 0
         throw(GurobiError(Env(modenv), ret))
@@ -276,9 +276,9 @@ end
 function set_dbl_param!(m::Model, name::String, v::Real)
 
     @assert isascii(name)
-    modenv = @grb_ccall(getenv, Ptr{Void}, (Ptr{Void},), m)
+    modenv = @grb_ccall(getenv, Ptr{Cvoid}, (Ptr{Cvoid},), m)
     @assert modenv != C_NULL
-    ret = @grb_ccall(setdblparam, Cint, (Ptr{Void}, Ptr{Cchar}, Float64),
+    ret = @grb_ccall(setdblparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Float64),
         modenv, name, v)
     if ret != 0
         throw(GurobiError(Env(modenv), ret))
@@ -289,9 +289,9 @@ function set_str_param!(m::Model, name::String, v::String)
 
     @assert isascii(name)
     @assert isascii(v)
-    modenv = @grb_ccall(getenv, Ptr{Void}, (Ptr{Void},), m)
+    modenv = @grb_ccall(getenv, Ptr{Cvoid}, (Ptr{Cvoid},), m)
     @assert modenv != C_NULL
-    ret = @grb_ccall(setstrparam, Cint, (Ptr{Void}, Ptr{Cchar}, Ptr{Cchar}),
+    ret = @grb_ccall(setstrparam, Cint, (Ptr{Cvoid}, Ptr{Cchar}, Ptr{Cchar}),
         modenv, name, v)
     if ret != 0
         throw(GurobiError(Env(modenv), ret))
@@ -331,4 +331,3 @@ function setparams!(env::Union{Env,Model}; args...)
         setparam!(env, string(name), v)
     end
 end
-

--- a/src/grb_solve.jl
+++ b/src/grb_solve.jl
@@ -2,7 +2,7 @@
 
 function optimize(model::Model)
     @assert model.ptr_model != C_NULL
-    ret = @grb_ccall(optimize, Cint, (Ptr{Void},), model)
+    ret = @grb_ccall(optimize, Cint, (Ptr{Cvoid},), model)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -11,7 +11,7 @@ end
 
 function computeIIS(model::Model)
     @assert model.ptr_model != C_NULL
-    ret = @grb_ccall(computeIIS, Cint, (Ptr{Void},), model)
+    ret = @grb_ccall(computeIIS, Cint, (Ptr{Cvoid},), model)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
@@ -42,7 +42,7 @@ const GRB_INPROGRESS      = 14
 const GRB_USER_OBJ_LIMIT  = 15
 
 const status_symbols = [
-    :loaded, 
+    :loaded,
     :optimal,
     :infeasible,
     :inf_or_unbd,
@@ -77,7 +77,7 @@ get_node_count(model::Model) = convert(Int, get_dblattr(model, "NodeCount"))
 mutable struct OptimInfo
     status::Symbol
     runtime::Float64
-    
+
     sol_count::Int
     iter_count::Int
     barrier_iter_count::Int
@@ -88,7 +88,7 @@ function get_optiminfo(model::Model)
     OptimInfo(
         get_status(model),
         get_runtime(model),
-        
+
         get_sol_count(model),
         get_iter_count(model),
         get_barrier_iter_count(model),
@@ -134,17 +134,17 @@ const basicmap_rev = Dict(
 )
 
 function get_basis(model::Model)
-    cval = Array{Cint}(num_vars(model))
-    cbasis = Array{Symbol}(num_vars(model))
+    cval = Array{Cint}(undef, num_vars(model))
+    cbasis = Array{Symbol}(undef, num_vars(model))
     get_intattrarray!(cval, model, "VBasis", 1)
     for it in 1:length(cval)
         cbasis[it] = varmap[cval[it]]
     end
-    
-    rval = Array{Cint}(num_constrs(model))
-    rbasis = Array{Symbol}(num_constrs(model))
+
+    rval = Array{Cint}(undef, num_constrs(model))
+    rbasis = Array{Symbol}(undef, num_constrs(model))
     get_intattrarray!(rval, model, "CBasis", 1)
-    rsense = Array{Cchar}(num_constrs(model))
+    rsense = Array{Cchar}(undef, num_constrs(model))
     get_charattrarray!(rsense, model, "Sense", 1)
     for it in 1:length(rval)
         rbasis[it] = conmap[rval[it]]
@@ -166,9 +166,9 @@ Load basis to a problem in form of primal solution.
 
     loadbasis(model::Model, rval::Vector{Symbol}, cval::Vector{Symbol})
 
-Load basis to a problem in terms of basicness description
-Variables\columns (in `cval`) can be: `:Basic`, `:NonbasicAtLower`, `:NonbasicAtUpper` and `:Superbasic`
-Constraints\rows (in `rval`) can be: `:Basic`, `:Nonbasic`
+Load basis to a problem in terms of basicness description Variables columns (in
+`cval`) can be: `:Basic`, `:NonbasicAtLower`, `:NonbasicAtUpper` and
+`:Superbasic` Constraints rows (in `rval`) can be: `:Basic`, `:Nonbasic`
 """
 function loadbasis(model::Model, x::Vector)
 
@@ -177,8 +177,8 @@ function loadbasis(model::Model, x::Vector)
 
     length(x) != ncols && error("solution candidate size is different from the number of columns")
 
-    cvals = Array{Cint}( ncols)
-    rvals = Array{Cint}( nrows)
+    cvals = Array{Cint}(undef, ncols)
+    rvals = Array{Cint}(undef, nrows)
 
     # obtain situation of columns
 
@@ -239,4 +239,3 @@ function loadbasis(model::Model, rval::Vector{Cint}, cval::Vector{Cint})
 
     return nothing
 end
-

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -15,7 +15,7 @@ function add_var!(model::Model, numnz::Integer, vind::Vector, vval::Vector{Float
         _boundwarning(lb, ub)
     end
     ret = @grb_ccall(addvar, Cint, (
-        Ptr{Void},    # model
+        Ptr{Cvoid},    # model
         Cint,         # numnz
         Ptr{Cint},    # vind
         Ptr{Float64}, # vval
@@ -25,7 +25,7 @@ function add_var!(model::Model, numnz::Integer, vind::Vector, vval::Vector{Float
         UInt8,        # vtype
         Ptr{UInt8}    # name
         ),
-        model, numnz, ivec(vind-1), vval, c, lb, ub, vtype, C_NULL)
+        model, numnz, ivec(vind.-1), vval, c, lb, ub, vtype, C_NULL)
 
     if ret != 0
         throw(GurobiError(model.env, ret))
@@ -41,7 +41,7 @@ function add_var!(model::Model, vtype::Cchar, c::Float64, lb::Float64, ub::Float
         _boundwarning(lb, ub)
     end
     ret = @grb_ccall(addvar, Cint, (
-        Ptr{Void},    # model
+        Ptr{Cvoid},    # model
         Cint,         # numnz
         Ptr{Cint},    # vind
         Ptr{Float64}, # vval
@@ -88,7 +88,7 @@ function add_vars!(model::Model, vtypes::CVec, c::FVec, lb::FVec, ub::FVec)
 
     # main call
     ret = @grb_ccall(addvars, Cint, (
-        Ptr{Void},  # model
+        Ptr{Cvoid},  # model
         Cint,       # numvars
         Cint,       # numnz
         Ptr{Cint},  # vbeg
@@ -126,10 +126,10 @@ del_vars!(model::Model, idx::Vector{T}) where {T<:Real} = del_vars!(model, conve
 function del_vars!(model::Model, idx::Vector{Cint})
     numdel = length(idx)
     ret = @grb_ccall(delvars, Cint, (
-                     Ptr{Void},
+                     Ptr{Cvoid},
                      Cint,
                      Ptr{Cint}),
-                     model, convert(Cint,numdel), idx-Cint(1))
+                     model, convert(Cint,numdel), idx.-Cint(1))
     if ret != 0
         throw(GurobiError(model.env, ret))
     end

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -7,19 +7,19 @@ const MOIB = MathOptInterface.Bridges
 @testset "Unit Tests" begin
     config = MOIT.TestConfig()
     solver = Gurobi.Optimizer(OutputFlag=0)
-    # TODO(@odow): see MathOptInterface Issue #404
-    # MOIT.basic_constraint_tests(solver, config)
+    MOIT.basic_constraint_tests(solver, config)
     MOIT.unittest(solver, config,
         ["solve_affine_interval", "solve_qcp_edge_cases"])
     @testset "solve_affine_interval" begin
-        MOIT.solve_affine_interval(
-            MOIB.SplitInterval{Float64}(Gurobi.Optimizer(OutputFlag=0)),
-            config
-        )
+        # TODO(odow): check why failing
+        # MOIT.solve_affine_interval(
+        #     MOIB.SplitInterval{Float64}(Gurobi.Optimizer(OutputFlag=0)),
+        #     config
+        # )
     end
     @testset "solve_qcp_edge_cases" begin
         MOIT.solve_qcp_edge_cases(solver,
-            MOIT.TestConfig(atol=1e-4)
+            MOIT.TestConfig(atol=1e-3)
         )
     end
     MOIT.modificationtest(solver, config, [
@@ -54,7 +54,7 @@ end
 @testset "Quadratic tests" begin
     MOIT.contquadratictest(
         Gurobi.Optimizer(OutputFlag=0),
-        MOIT.TestConfig(atol=1e-4, rtol=1e-4, duals=false, query=false)
+        MOIT.TestConfig(atol=1e-3, rtol=1e-3, duals=false, query=false)
     )
 end
 
@@ -90,8 +90,7 @@ end
         MOIT.emptytest(solver)
     end
     @testset "orderedindicestest" begin
-        # TODO(@odow): see MathOptInterface Issue #404
-        # MOIT.orderedindicestest(solver)
+        MOIT.orderedindicestest(solver)
     end
     @testset "copytest" begin
         MOIT.copytest(solver, Gurobi.Optimizer())
@@ -195,8 +194,8 @@ end
 
 @testset "LQOI Issue #38" begin
     # https://github.com/JuliaOpt/LinQuadOptInterface.jl/issues/38#issuecomment-407625187
-    _getinner(opt::GurobiOptimizer) = opt.inner
-    @inferred _getinner(GurobiOptimizer())
+    _getinner(opt::Gurobi.Optimizer) = opt.inner
+    @inferred _getinner(Gurobi.Optimizer())
 end
 
 @testset "User limit handling (issue #140)" begin
@@ -221,7 +220,11 @@ end
     # Given a collection of items with individual weights and values,
     # maximize the total value carried subject to the constraint that
     # the total weight carried is less than 10.
-    srand(1)
+    if VERSION >= v"0.7-"
+        Random.seed!(1)
+    else
+        srand(1)
+    end
     item_weights = rand(N)
     item_values = rand(N)
     MOI.addconstraint!(m,
@@ -239,7 +242,7 @@ end
 end
 
 @testset "Constant objective (issue #111)" begin
-    m = GurobiOptimizer()
+    m = Gurobi.Optimizer()
     x = MOI.addvariable!(m)
     MOI.set!(m, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[], 2.0))

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -11,11 +11,10 @@ const MOIB = MathOptInterface.Bridges
     MOIT.unittest(solver, config,
         ["solve_affine_interval", "solve_qcp_edge_cases"])
     @testset "solve_affine_interval" begin
-        # TODO(odow): check why failing
-        # MOIT.solve_affine_interval(
-        #     MOIB.SplitInterval{Float64}(Gurobi.Optimizer(OutputFlag=0)),
-        #     config
-        # )
+        MOIT.solve_affine_interval(
+            MOIB.SplitInterval{Float64}(Gurobi.Optimizer(OutputFlag=0)),
+            config
+        )
     end
     @testset "solve_qcp_edge_cases" begin
         MOIT.solve_qcp_edge_cases(solver,

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -6,14 +6,14 @@ const MOIB = MathOptInterface.Bridges
 
 @testset "Unit Tests" begin
     config = MOIT.TestConfig()
-    solver = GurobiOptimizer(OutputFlag=0)
+    solver = Gurobi.Optimizer(OutputFlag=0)
     # TODO(@odow): see MathOptInterface Issue #404
     # MOIT.basic_constraint_tests(solver, config)
     MOIT.unittest(solver, config,
         ["solve_affine_interval", "solve_qcp_edge_cases"])
     @testset "solve_affine_interval" begin
         MOIT.solve_affine_interval(
-            MOIB.SplitInterval{Float64}(GurobiOptimizer(OutputFlag=0)),
+            MOIB.SplitInterval{Float64}(Gurobi.Optimizer(OutputFlag=0)),
             config
         )
     end
@@ -29,7 +29,7 @@ end
 
 @testset "Linear tests" begin
     @testset "Default Solver"  begin
-        solver = GurobiOptimizer(OutputFlag=0)
+        solver = Gurobi.Optimizer(OutputFlag=0)
         MOIT.contlineartest(solver, MOIT.TestConfig(), [
             # This requires interval constraint.
             "linear10",
@@ -39,13 +39,13 @@ end
     end
     @testset "linear10" begin
         MOIT.linear10test(
-            MOIB.SplitInterval{Float64}(GurobiOptimizer(OutputFlag=0)),
+            MOIB.SplitInterval{Float64}(Gurobi.Optimizer(OutputFlag=0)),
             MOIT.TestConfig()
         )
     end
     @testset "No certificate" begin
         MOIT.linear12test(
-            GurobiOptimizer(OutputFlag=0, InfUnbdInfo=0),
+            Gurobi.Optimizer(OutputFlag=0, InfUnbdInfo=0),
             MOIT.TestConfig(infeas_certificates=false)
         )
     end
@@ -53,33 +53,33 @@ end
 
 @testset "Quadratic tests" begin
     MOIT.contquadratictest(
-        GurobiOptimizer(OutputFlag=0),
+        Gurobi.Optimizer(OutputFlag=0),
         MOIT.TestConfig(atol=1e-4, rtol=1e-4, duals=false, query=false)
     )
 end
 
 @testset "Linear Conic tests" begin
     MOIT.lintest(
-        GurobiOptimizer(OutputFlag=0),
+        Gurobi.Optimizer(OutputFlag=0),
         MOIT.TestConfig()
     )
 end
 
 @testset "Integer Linear tests" begin
     MOIT.intlineartest(
-        GurobiOptimizer(OutputFlag=0),
+        Gurobi.Optimizer(OutputFlag=0),
         MOIT.TestConfig(),
         ["int3"]  # int3 has interval constriants
     )
     @testset "int3" begin
         MOIT.int3test(
-            MOIB.SplitInterval{Float64}(GurobiOptimizer(OutputFlag=0)),
+            MOIB.SplitInterval{Float64}(Gurobi.Optimizer(OutputFlag=0)),
             MOIT.TestConfig()
         )
     end
 end
 @testset "ModelLike tests" begin
-    solver = GurobiOptimizer()
+    solver = Gurobi.Optimizer()
     @testset "nametest" begin
         MOIT.nametest(solver)
     end
@@ -94,13 +94,13 @@ end
         # MOIT.orderedindicestest(solver)
     end
     @testset "copytest" begin
-        MOIT.copytest(solver, GurobiOptimizer())
+        MOIT.copytest(solver, Gurobi.Optimizer())
     end
 end
 
 @testset "Gurobi Callback" begin
     @testset "Generic callback" begin
-        m = GurobiOptimizer(OutputFlag=0)
+        m = Gurobi.Optimizer(OutputFlag=0)
         x = MOI.addvariable!(m)
         MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
         MOI.set!(m, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -126,7 +126,7 @@ end
     end
 
     @testset "Lazy cut" begin
-        m = GurobiOptimizer(OutputFlag=0, Cuts=0, Presolve=0, Heuristics=0, LazyConstraints=1)
+        m = Gurobi.Optimizer(OutputFlag=0, Cuts=0, Presolve=0, Heuristics=0, LazyConstraints=1)
         MOI.Utilities.loadfromstring!(m,"""
             variables: x, y
             maxobjective: y
@@ -203,12 +203,12 @@ end
     # Verify that we return the correct status codes when a mixed-integer
     # problem has been solved to a *feasible* but not necessarily optimal
     # solution. To do that, we will set up an intentionally dumbed-down
-    # Gurobi optimizer (with all heuristics and pre-solve turned off) and
+    # Gurobi Gurobi.Optimizer (with all heuristics and pre-solve turned off) and
     # ask it to solve a classic knapsack problem. Setting SolutionLimit=1
     # forces the solver to return after its first feasible MIP solution,
     # which tests the right part of the code without relying on potentially
     # flaky or system-dependent time limits.
-    m = GurobiOptimizer(OutputFlag=0,
+    m = Gurobi.Optimizer(OutputFlag=0,
                         SolutionLimit=1,
                         Heuristics=0.0,
                         Presolve=0)

--- a/test/MOIWrapper.jl
+++ b/test/MOIWrapper.jl
@@ -29,7 +29,7 @@ end
 
 @testset "Linear tests" begin
     @testset "Default Solver"  begin
-        solver = GurobiOptimizer(OutputFlag=0, InfUnbdInfo=1)
+        solver = GurobiOptimizer(OutputFlag=0)
         MOIT.contlineartest(solver, MOIT.TestConfig(), [
             # This requires interval constraint.
             "linear10",
@@ -45,7 +45,7 @@ end
     end
     @testset "No certificate" begin
         MOIT.linear12test(
-            GurobiOptimizer(OutputFlag=0),
+            GurobiOptimizer(OutputFlag=0, InfUnbdInfo=0),
             MOIT.TestConfig(infeas_certificates=false)
         )
     end
@@ -60,7 +60,7 @@ end
 
 @testset "Linear Conic tests" begin
     MOIT.lintest(
-        GurobiOptimizer(OutputFlag=0, InfUnbdInfo=1),
+        GurobiOptimizer(OutputFlag=0),
         MOIT.TestConfig()
     )
 end

--- a/test/MathProgBase/env.jl
+++ b/test/MathProgBase/env.jl
@@ -1,4 +1,4 @@
-using Gurobi, MathProgBase, Base.Test
+using Gurobi, MathProgBase, Compat.Test
 
 @testset "Env" begin
     env = Gurobi.Env()

--- a/test/MathProgBase/large_coefficients.jl
+++ b/test/MathProgBase/large_coefficients.jl
@@ -1,20 +1,22 @@
-using Gurobi, MathProgBase, Base.Test
+using Gurobi, MathProgBase, Compat.Test
+
+using Compat: undef
 
 @testset "Large Coefficients" begin
 
     @testset "Large Objective Coefficients" begin
         # Min   1.1e100x
         #       x >= 1
-        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [1],[Inf], [1.1e100], Float64[], Float64[], :Min)
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver(OutputFlag=0))
+        MathProgBase.loadproblem!(m, Array{Float64}(undef, 0, 1), [1],[Inf], [1.1e100], Float64[], Float64[], :Min)
         MathProgBase.optimize!(m)
         @test MathProgBase.getsolution(m) == [1.0]
         @test MathProgBase.getobjval(m) == 1e100
 
         # Max   -1.1e100x
         #       x >= 1
-        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [1],[Inf], [-1.1e100], Float64[], Float64[], :Max)
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver(OutputFlag=0))
+        MathProgBase.loadproblem!(m, Array{Float64}(undef, 0, 1), [1],[Inf], [-1.1e100], Float64[], Float64[], :Max)
         MathProgBase.optimize!(m)
         @test MathProgBase.getsolution(m) == [1.0]
         @test MathProgBase.getobjval(m) == -1e100
@@ -23,29 +25,29 @@ using Gurobi, MathProgBase, Base.Test
     @testset "Large Variable Bounds" begin
         # Min   x
         #       x >= 1.1e30
-        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [1.1e30],[Inf], [1], Float64[], Float64[], :Min)
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver(OutputFlag=0))
+        MathProgBase.loadproblem!(m, Array{Float64}(undef, 0, 1), [1.1e30],[Inf], [1], Float64[], Float64[], :Min)
         MathProgBase.optimize!(m)
         @test MathProgBase.status(m) == :Infeasible
 
         # Max   x
         #       x <= -1.1e30
-        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [-Inf],[-1.1e30], [1], Float64[], Float64[], :Max)
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver(OutputFlag=0))
+        MathProgBase.loadproblem!(m, Array{Float64}(undef, 0, 1), [-Inf],[-1.1e30], [1], Float64[], Float64[], :Max)
         MathProgBase.optimize!(m)
         @test MathProgBase.status(m) == :Infeasible
 
         # Min   x
         #       x >= -1.1e30
-        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [-1.1e30],[Inf], [1], Float64[], Float64[], :Min)
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver(OutputFlag=0))
+        MathProgBase.loadproblem!(m, Array{Float64}(undef, 0, 1), [-1.1e30],[Inf], [1], Float64[], Float64[], :Min)
         MathProgBase.optimize!(m)
         @test MathProgBase.status(m) == :Unbounded
 
         # Max   x
         #       x <= 1.1e30
-        m = MathProgBase.LinearQuadraticModel(GurobiSolver())
-        MathProgBase.loadproblem!(m, Array{Float64}(0, 1), [-Inf],[1.1e30], [1], Float64[], Float64[], :Max)
+        m = MathProgBase.LinearQuadraticModel(GurobiSolver(OutputFlag=0))
+        MathProgBase.loadproblem!(m, Array{Float64}(undef, 0, 1), [-Inf],[1.1e30], [1], Float64[], Float64[], :Max)
         MathProgBase.optimize!(m)
         @test MathProgBase.status(m) == :Unbounded
 

--- a/test/MathProgBase/lp_01a.jl
+++ b/test/MathProgBase/lp_01a.jl
@@ -8,13 +8,13 @@
 #
 #   solution: x = 45, y = 6.25, objv = 51.25
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test, Compat.GC
 
 @testset "LP 01a" begin
     env = Gurobi.Env()
+    setparam!(env, "OutputFlag", 0)
 
     method = getparam(env, "Method")
-    println("method = $method")
 
     model = Gurobi.Model(env, "lp_01", :maximize)
 
@@ -28,18 +28,14 @@ using Gurobi, Base.Test
     add_constr!(model, [30., 33.], '<', 2100.)
     update_model!(model)
 
-    println(model)
-
     # perform optimization
     optimize(model)
 
     # show results
     info = get_optiminfo(model)
-    println()
-    println(info)
 
     @test get_solution(model) == [45, 6.25]
     @test get_objval(model) == 51.25
 
-    gc()  # test finalizers
+    GC.gc()  # test finalizers
 end

--- a/test/MathProgBase/lp_01b.jl
+++ b/test/MathProgBase/lp_01b.jl
@@ -8,15 +8,15 @@
 #
 #   solution: x = 45, y = 6.25, objv = 51.25
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test, Compat.GC
 
 @testset "LP 01b" begin
 
     env = Gurobi.Env()
+    setparam!(env, "OutputFlag", 0)
     setparams!(env, Method=2)  # using barrier method
 
     method = getparam(env, "Method")
-    println("method = $method")
 
     model = Gurobi.Model(env, "lp_01", :maximize)
 
@@ -29,15 +29,11 @@ using Gurobi, Base.Test
         [50., 24., 30., 33.], '<', [2400., 2100.])
     update_model!(model)
 
-    println(model)
-
     # perform optimization
     optimize(model)
 
     # show results
     info = get_optiminfo(model)
-    println()
-    println(info)
 
     sol = get_solution(model)
     @test sol == [45, 6.25]
@@ -45,5 +41,5 @@ using Gurobi, Base.Test
     objv = get_objval(model)
     @test objv == 51.25
 
-    gc()  # test finalizers
+    GC.gc()  # test finalizers
 end

--- a/test/MathProgBase/lp_02.jl
+++ b/test/MathProgBase/lp_02.jl
@@ -11,11 +11,12 @@
 #   objv: 71818.1818
 #
 
-using MathProgBase, Gurobi, Base.Test
+using MathProgBase, Gurobi, Compat.Test
 
 @testset "LP 02" begin
 
 	env = Gurobi.Env()
+	setparam!(env, "OutputFlag", 0)
 
 	model = gurobi_model(env;
 		name="lp_02",
@@ -24,8 +25,6 @@ using MathProgBase, Gurobi, Base.Test
 		A = [-1. 1.5; 12. 8.; 1000. 300.],
 		b = [0., 1000., 70000.],
 		lb = [0., 30.])
-
-	println(model)
 
 	optimize(model)
 

--- a/test/MathProgBase/lp_03.jl
+++ b/test/MathProgBase/lp_03.jl
@@ -1,9 +1,10 @@
 # Test get/set objective coefficients in LP
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test, Compat.GC
 
 @testset "LP 03" begin
 	env = Gurobi.Env()
+	setparam!(env, "OutputFlag", 0)
 
 	# original model
 	#
@@ -18,8 +19,6 @@ using Gurobi, Base.Test
 		f=[2.0, 2.0],
 		lb=[0.2, 0.2],
 		ub=[1.0, 1.0])
-
-	println(model)
 
 	lb_ = lowerbounds(model)
 	ub_ = upperbounds(model)
@@ -52,5 +51,5 @@ using Gurobi, Base.Test
 	@test get_solution(model) == [1.0, 0.2]
 	@test get_objval(model) == 0.8
 
-	gc()
+	GC.gc()
 end

--- a/test/MathProgBase/lp_04.jl
+++ b/test/MathProgBase/lp_04.jl
@@ -15,10 +15,11 @@
 #
 #   solution: x = 1.3333333, y = 1.3333333, objv = 2.66666666
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test, Compat.GC
 
 @testset "LP 04" begin
     env = Gurobi.Env()
+    setparam!(env, "OutputFlag", 0)
     setparams!(env, Method=2)  # using barrier method
 
     method = getparam(env, "Method")
@@ -102,5 +103,5 @@ using Gurobi, Base.Test
     @test isapprox(get_solution(model), [2.0], atol=1e-4)
     @test isapprox(get_objval(model), 2.0, atol=1e-4)
 
-    gc()  # test finalizers
+    GC.gc()  # test finalizers
 end

--- a/test/MathProgBase/mathprog.jl
+++ b/test/MathProgBase/mathprog.jl
@@ -1,30 +1,43 @@
 using Gurobi
+import MathProgBase
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","linprog.jl"))
-linprogtest(GurobiSolver(InfUnbdInfo=1))
+if VERSION >= v"0.7-"
+    using Compat.Pkg
+end
+
+function mathprogbase_file(file::String)
+    if VERSION >= v"0.7-"
+        return joinpath(dirname(dirname(pathof(MathProgBase))), "test", file)
+    else
+        return joinpath(Pkg.dir("MathProgBase"), "test", file)
+    end
+end
+
+include(mathprogbase_file("linprog.jl"))
+linprogtest(GurobiSolver(OutputFlag=0, InfUnbdInfo=1))
 
 s = GurobiSolver()
 MathProgBase.setparameters!(s, Silent=true, TimeLimit=100.0)
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","linproginterface.jl"))
+include(mathprogbase_file("linproginterface.jl"))
 linprogsolvertest(s)
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","mixintprog.jl"))
-mixintprogtest(GurobiSolver())
+include(mathprogbase_file("mixintprog.jl"))
+mixintprogtest(GurobiSolver(OutputFlag=0))
 
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","quadprog.jl"))
-quadprogtest(GurobiSolver())
-socptest(GurobiSolver())
-qpdualtest(GurobiSolver(QCPDual=1))
+include(mathprogbase_file("quadprog.jl"))
+quadprogtest(GurobiSolver(OutputFlag=0))
+socptest(GurobiSolver(OutputFlag=0))
+qpdualtest(GurobiSolver(OutputFlag=0, QCPDual=1))
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","conicinterface.jl"))
-coniclineartest(GurobiSolver())
+include(mathprogbase_file("conicinterface.jl"))
+coniclineartest(GurobiSolver(OutputFlag=0))
 # The following tests are not passing on Gurobi 8.0.0 due to known bug
 # on infeasibility check of SOC models.
 # https://github.com/JuliaOpt/Gurobi.jl/pull/123
 if Gurobi.version < v"8.0.0"
-    conicSOCtest(GurobiSolver())
-    conicSOCRotatedtest(GurobiSolver())
+    conicSOCtest(GurobiSolver(OutputFlag=0))
+    conicSOCRotatedtest(GurobiSolver(OutputFlag=0))
 end
-conicSOCINTtest(GurobiSolver())
+conicSOCINTtest(GurobiSolver(OutputFlag=0))

--- a/test/MathProgBase/mip_01.jl
+++ b/test/MathProgBase/mip_01.jl
@@ -10,10 +10,11 @@
 #         z is binary
 #
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test
 
 @testset "MIP 01" begin
     env = Gurobi.Env()
+    setparam!(env, "OutputFlag", 0)
 
     model = Gurobi.Model(env, "mip_01", :maximize)
 
@@ -24,8 +25,6 @@ using Gurobi, Base.Test
 
     add_constr!(model, ones(3), '<', 10.)
     add_constr!(model, [1., 2., 1.], '<', 15.)
-
-    println(model)
 
     optimize(model)
     @test get_solution(model) == [0.0, 7.0, 1.0]

--- a/test/MathProgBase/multiobj.jl
+++ b/test/MathProgBase/multiobj.jl
@@ -1,9 +1,10 @@
 # hierarchical multi-objetive LP
 #
 
-using Gurobi
+using Gurobi, Compat.Test
 
 env = Gurobi.Env()
+setparam!(env, "OutputFlag", 0)
 
 A = [1. 1.]
 lb = [0.; 0.]
@@ -19,10 +20,10 @@ Gurobi.set_multiobj!(model, 2, [1., 0.], 1, 1.0)
 Gurobi.update_model!(model)
 
 optimize(model)
-Test.@test get_solution(model) == [1., 0.]
+@test get_solution(model) == [1., 0.]
 
 Gurobi.set_multiobj!(model, 2, [0., 1.], 1, 1.0)
 Gurobi.update_model!(model)
 
 optimize(model)
-Test.@test get_solution(model) == [0., 1.]
+@test get_solution(model) == [0., 1.]

--- a/test/MathProgBase/qcqp_01.jl
+++ b/test/MathProgBase/qcqp_01.jl
@@ -6,11 +6,12 @@
 #
 #    solution: (0.71, 0.71) objv = 1.414
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test
 
 @testset "QCQP1" begin
 
     env = Gurobi.Env()
+    setparam!(env, "OutputFlag", 0)
 
     model = Gurobi.Model(env, "qcqp_01", :maximize)
 
@@ -20,8 +21,6 @@ using Gurobi, Base.Test
      # add_qpterms!(model, linearindices, linearcoeffs, qrowinds, qcolinds, qcoeffs, sense, rhs)
     add_qconstr!(model, [], [], [1, 2], [1, 2], [1, 1.], '<', 1.0)
     update_model!(model)
-
-    println(model)
 
     optimize(model)
 

--- a/test/MathProgBase/qp_01.jl
+++ b/test/MathProgBase/qp_01.jl
@@ -8,11 +8,12 @@
 #    solution: (0.25, 0.75), objv = 1.875
 #
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test
 
 @testset "QP1" begin
 
     env = Gurobi.Env()
+    setparam!(env, "OutputFlag", 0)
 
     model = Gurobi.Model(env, "qp_01")
 
@@ -22,8 +23,6 @@ using Gurobi, Base.Test
     add_qpterms!(model, [1, 1, 2], [1, 2, 2], [2., 1., 1.])
     add_constr!(model, [1., 1.], '=', 1.)
     update_model!(model)
-
-    println(model)
 
     optimize(model)
 

--- a/test/MathProgBase/qp_02.jl
+++ b/test/MathProgBase/qp_02.jl
@@ -6,11 +6,12 @@
 #           x +   y       >= 1
 #
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test
 
 @testset "QP2" begin
 
 	env = Gurobi.Env()
+	setparam!(env, "OutputFlag", 0)
 
 	model = gurobi_model(env;
 		name = "qp_02",

--- a/test/MathProgBase/range_constraints.jl
+++ b/test/MathProgBase/range_constraints.jl
@@ -1,9 +1,9 @@
-using Gurobi, MathProgBase, Base.Test
+using Gurobi, MathProgBase, Compat.Test
 
 @testset "Range Constraints" begin
 
     # Test Range constraints pass
-    m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+    m = MathProgBase.LinearQuadraticModel(GurobiSolver(OutputFlag=0))
     MathProgBase.loadproblem!(m, [1 1], [0, 0],[1,1], [1,1], [0], [1], :Max)
     MathProgBase.optimize!(m)
 

--- a/test/MathProgBase/reformulation_bug.jl
+++ b/test/MathProgBase/reformulation_bug.jl
@@ -3,7 +3,7 @@ using Gurobi, MathProgBase
 # This problem should error out on Gurobi Versions 6.5.2 and earlier,
 # but pass on later versions
 
-m = MathProgBase.LinearQuadraticModel(GurobiSolver())
+m = MathProgBase.LinearQuadraticModel(GurobiSolver(OutputFlag=0))
 
 # Max           z
 # s.t.  x + y     >= 0

--- a/test/MathProgBase/test_get_strarray.jl
+++ b/test/MathProgBase/test_get_strarray.jl
@@ -1,4 +1,4 @@
-using Gurobi, Base.Test
+using Gurobi, Compat.Test
 
 @testset "GRB String Attributes" begin
     # enviroment and problem

--- a/test/MathProgBase/test_grb_attrs.jl
+++ b/test/MathProgBase/test_grb_attrs.jl
@@ -10,7 +10,7 @@
 #         z is binary
 #
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test
 
 @testset "GRB Attributes" begin
     env = Gurobi.Env()

--- a/test/MathProgBase/test_read.jl
+++ b/test/MathProgBase/test_read.jl
@@ -10,7 +10,7 @@
 #         p1 is integer: 0 <= p3
 #         z is binary
 
-using Gurobi, Base.Test
+using Gurobi, Compat.Test
 
 @testset "test_read" begin
 # The function read() is used to produce a MIP start vector
@@ -21,6 +21,7 @@ using Gurobi, Base.Test
     #-------------
 
     simple_model_env = Gurobi.Env()
+    setparam!(simple_model_env, "OutputFlag", 0)
 
     simple_model = Gurobi.Model(simple_model_env, "simple_mip", :maximize)
 

--- a/test/c_wrapper.jl
+++ b/test/c_wrapper.jl
@@ -1,7 +1,19 @@
-using Gurobi
-using Base.Test
 using Gurobi: getcoeff
 
+@testset "Empty constraints (Issue #142)" begin
+    @testset "No variables, no constraints" begin
+        model = Gurobi.Model(Gurobi.Env(), "model")
+        A = Gurobi.get_constrmatrix(model)
+        @test size(A) == (0, 0)
+    end
+    @testset "One variable, no constraints" begin
+        model = Gurobi.Model(Gurobi.Env(), "model")
+        Gurobi.add_cvar!(model, 0.0)
+        Gurobi.update_model!(model)
+        A = Gurobi.get_constrmatrix(model)
+        @test size(A) == (0, 1)
+    end
+end
 
 @testset "changing coefficients" begin
     A = spzeros(2, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,8 @@
-using Base.Test
+using Gurobi, Base.Test
+
+@testset "C API" begin
+    include("c_wrapper.jl")
+end
 
 const mpb_tests = [
     "lp_01a",
@@ -29,22 +33,5 @@ const mpb_tests = [
 end
 
 @testset "MathOptInterface Tests" begin
-    evalfile("MOIWrapper.jl")
-end
-
-include("constraint_modification.jl")
-
-@testset "Empty constraints (Issue #142)" begin
-    @testset "No variables, no constraints" begin
-        model = Gurobi.Model(Gurobi.Env(), "model")
-        A = Gurobi.get_constrmatrix(model)
-        @test size(A) == (0, 0)
-    end
-    @testset "One variable, no constraints" begin
-        model = Gurobi.Model(Gurobi.Env(), "model")
-        Gurobi.add_cvar!(model, 0.0)
-        Gurobi.update_model!(model)
-        A = Gurobi.get_constrmatrix(model)
-        @test size(A) == (0, 1)
-    end
+    include("MOIWrapper.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,7 @@
-using Gurobi, Base.Test
+using Gurobi
+
+using Compat
+using Compat.Test, Compat.SparseArrays, Compat.Random
 
 @testset "C API" begin
     include("c_wrapper.jl")
@@ -25,10 +28,8 @@ const mpb_tests = [
 ]
 
 @testset "MathProgBase Tests" begin
-    for t in mpb_tests
-        fp = "$(t).jl"
-        println("running $(fp) ...")
-        evalfile(joinpath("MathProgBase", fp))
+    for file in mpb_tests
+        evalfile(joinpath("MathProgBase", "$(file).jl"))
     end
 end
 


### PR DESCRIPTION
Cleans up the MOIWrapper following the spirit of https://github.com/JuliaOpt/GLPK.jl/pull/59

So far, there are five commits.

#### Commit 1 https://github.com/JuliaOpt/Gurobi.jl/pull/146/commits/fb07d8f9dc783816ba16b8ac998b26eba673be51

The first commit does some renaming, removes some allocations by calling `get_dblattrelement` instead of making one-element arrays (e.g. [here](https://github.com/JuliaOpt/Gurobi.jl/pull/146/files#diff-3b39d17ea281f7c0a7e126ffc77935cfR109)). It also adds a few tests that were skipped.

#### Commit 2 https://github.com/JuliaOpt/Gurobi.jl/pull/146/commits/080b2f774191a2a85994f83a695817b44f6dd246

This commit sets `InfUnbdInfo=1` by default so that the default behavior with `GurobiSolver()` is kept (introduced by https://github.com/JuliaOpt/Gurobi.jl/commit/ecb8a88a158374eac40bf4a073ab5e52666ffcce).

#### Commit 3 https://github.com/JuliaOpt/Gurobi.jl/pull/146/commits/30819f2aaa0cd829f02ba12155c1995ac9b0321e

Refactors `GurobiOptimizer` into the unexported `Gurobi.Optimizer` which was the consensus of https://github.com/JuliaOpt/MathOptInterface.jl/issues/425

#### Commit 4 https://github.com/JuliaOpt/Gurobi.jl/pull/146/commits/59808969318576009bfee8ba5f3999a003b80901

Some minor fixes.

#### Commit 5 https://github.com/JuliaOpt/Gurobi.jl/pull/146/commits/e16363e64f4ba602396c8d5bce9dc897fd44e292

Lots of deprecation fixes for v0.7

This is ready to be merged once REQUIRE is updated with a new LQOI tag:
- [x] update require with LQOI tag (Ref https://github.com/JuliaLang/METADATA.jl/pull/16319)