### PR TITLE
fix #152

### DIFF
--- a/src/grb_constrs.jl
+++ b/src/grb_constrs.jl
@@ -1,4 +1,4 @@
-# work around for julia issue #28948
+# work around for julia issue #28948, Gurobi.jl issue #152
 if VERSION ≤ v"0.7-"
     sparse_transpose(A) = sparse(transpose(A))
 else

--- a/src/grb_constrs.jl
+++ b/src/grb_constrs.jl
@@ -1,7 +1,13 @@
+# work around for julia issue #28948
+if VERSION ≤ v"0.7-"
+    sparse_transpose(A) = sparse(transpose(A))
+else
+    sparse_transpose(A) = SparseMatrixCSC(transpose(A))
+end
+
 ## Add Linear constraints
 
 # add single constraint
-
 function add_constr!(model::Model, inds::IVec, coeffs::FVec, rel::Cchar, rhs::Float64)
     length(inds) == length(coeffs) || error("Inconsistent argument dimensions.")
     ret = @grb_ccall(addconstr, Cint, (
@@ -78,7 +84,7 @@ end
 function add_constrs!(model::Model, A::CoeffMat, rel::GCharOrVec, b::Vector{Float64})
     m, n = size(A)
     (m == length(b) && n == num_vars(model)) || error("Incompatible argument dimensions.")
-    add_constrs_t!(model, sparse(transpose(A)), rel, b)
+    add_constrs_t!(model, sparse_transpose(A), rel, b)
 end
 
 
@@ -156,7 +162,7 @@ function add_rangeconstrs!(model::Model, A::CoeffMat, lb::Vector, ub::Vector)
     m, n = size(A)
     (m == length(lb) == length(ub) && n == num_vars(model)) || error("Incompatible argument dimensions.")
 
-    add_rangeconstrs_t!(model, sparse(transpose(A)), lb, ub)
+    add_rangeconstrs_t!(model, sparse_transpose(A), lb, ub)
 end
 
 function get_constrmatrix(model::Model)

--- a/src/grb_constrs.jl
+++ b/src/grb_constrs.jl
@@ -8,6 +8,7 @@ end
 ## Add Linear constraints
 
 # add single constraint
+
 function add_constr!(model::Model, inds::IVec, coeffs::FVec, rel::Cchar, rhs::Float64)
     length(inds) == length(coeffs) || error("Inconsistent argument dimensions.")
     ret = @grb_ccall(addconstr, Cint, (


### PR DESCRIPTION
Ok, here is a fix to a rather scary regression that I was afraid would be a nightmare to fix.  The problem is [this](https://github.com/JuliaLang/julia/issues/28948) Julia "bug".  It's really just that `sparse` is missing the appropriate methods for computing a sparse matrix from the transpose of a sparse matrix.  Fortunately, those methods are only missing from `sparse`, calling the `SparseMatrixCSC` constructor works just fine.

I have tested this on my large problems and it now seems at least as fast on 1.0 as it was on 0.6.4.

I believe this would have affected both `MPB` and `MOI`.