### PR TITLE
fix missing "numvar" method during MIPNode heuristic callback

### DIFF
--- a/src/MPBWrapper.jl
+++ b/src/MPBWrapper.jl
@@ -696,7 +696,7 @@ function mastercallback(ptr_model::Ptr{Cvoid}, cbdata::Ptr{Cvoid}, where::Cint, 
         end
     end
     if model.heuristiccb != nothing && state == :MIPNode
-        grbcb.sol = fill(1e101, numvar(model))  # GRB_UNDEFINED
+        grbcb.sol = fill(1e101, MPB.numvar(model))  # GRB_UNDEFINED
         ret = model.heuristiccb(grbcb)
         if ret == :Exit
             terminate(model.inner)


### PR DESCRIPTION
this seemed to fix an issue I was encountering with some Pajarito models on Julia 0.6.4