### PR TITLE
Improve setting of variable bounds

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -136,33 +136,15 @@ LQOI.backend_type(::Optimizer, ::MOI.Zeros)                = Cchar('=')
 LQOI.backend_type(::Optimizer, ::MOI.Nonpositives)         = Cchar('<')
 LQOI.backend_type(::Optimizer, ::MOI.Nonnegatives)         = Cchar('>')
 
-function LQOI.change_variable_bounds!(model::Optimizer,
-          columns::Vector{Int}, new_bounds::Vector{Float64},
-          senses::Vector{Cchar})
-    number_lower_bounds = count(x->x==Cchar('L'), senses)
-    lower_cols   = fill(0, number_lower_bounds)
-    lower_values = fill(0.0, number_lower_bounds)
-    number_upper_bounds = count(x->x==Cchar('U'), senses)
-    upper_cols   = fill(0, number_upper_bounds)
-    upper_values = fill(0.0, number_upper_bounds)
-    lower_index = 1
-    upper_index = 1
+function LQOI.change_variable_bounds!(
+        model::Optimizer, columns::Vector{Int}, new_bounds::Vector{Float64},
+        senses::Vector{Cchar})
     for (column, bound, sense) in zip(columns, new_bounds, senses)
         if sense == Cchar('L')
-            lower_cols[lower_index]   = column
-            lower_values[lower_index] = bound
-            lower_index += 1
-        elseif sense == Cchar('U')
-            upper_cols[upper_index]   = column
-            upper_values[upper_index] = bound
-            upper_index += 1
+            set_dblattrlist!(model.inner, "LB", column, bound)
+        else
+            set_dblattrlist!(model.inner, "UB", column, bound)
         end
-    end
-    if number_lower_bounds > 0
-        set_dblattrlist!(model.inner, "LB", lower_cols, lower_values)
-    end
-    if number_upper_bounds > 0
-        set_dblattrlist!(model.inner, "UB", upper_cols, upper_values)
     end
     _require_update(model)
     return

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -141,9 +141,9 @@ function LQOI.change_variable_bounds!(
         senses::Vector{Cchar})
     for (column, bound, sense) in zip(columns, new_bounds, senses)
         if sense == Cchar('L')
-            set_dblattrlist!(model.inner, "LB", column, bound)
+            set_dblattrelement!(model.inner, "LB", column, bound)
         else
-            set_dblattrlist!(model.inner, "UB", column, bound)
+            set_dblattrelement!(model.inner, "UB", column, bound)
         end
     end
     _require_update(model)


### PR DESCRIPTION
Closes #168

@joaquimg until JuMP outputs nicely vectorized code, we should be overloading the singular `set_variable_bound` instead of just `change_variable_bounds!`.

```julia
using Gurobi, BenchmarkTools

const gurobi_env = Gurobi.Env()
const LQOI = Gurobi.LQOI

function benchmark_3a(model, x)
	for i in 1:length(x)
		LQOI.set_variable_bound(model, MOI.SingleVariable(x[i]), MOI.GreaterThan(1.0 * i))
	end
	Gurobi.update_model!(model.inner)
end

function benchmark_3b(model, x)
	for i in 1:length(x)
		MOI.add_constraint(
			model, MOI.SingleVariable(x[i]), MOI.GreaterThan(1.0 * i))
	end
	Gurobi.update_model!(model.inner)
end

function benchmark_3c(model, x)
	MOI.add_constraints(
		model,
		MOI.SingleVariable.(x),
		[MOI.GreaterThan(1.0 * i) for i in 1:length(x)]
	)
	Gurobi.update_model!(model.inner)
end

function setup_3(N)
	model = Gurobi.Optimizer(gurobi_env)
	x = MOI.add_variables(model, N)
	return model, x
end

@btime benchmark_3a(model, x) setup = ((model, x) = setup_3(100))
@btime benchmark_3b(model, x) setup = ((model, x) = setup_3(100))
@btime benchmark_3c(model, x) setup = ((model, x) = setup_3(100))
```

```
C:\Users\Oscar\.julia\dev\Gurobi>julia --color=yes perf/benchmark_jump.jl
Academic license - for non-commercial use only
68.148 μs (0 allocations: 0 bytes)
246.729 μs (260 allocations: 11.55 KiB)
59.937 μs (184 allocations: 18.97 KiB)

C:\Users\Oscar\.julia\dev\Gurobi>git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

C:\Users\Oscar\.julia\dev\Gurobi>julia --color=yes perf/benchmark_jump.jl
Academic license - for non-commercial use only
147.380 μs (1300 allocations: 117.19 KiB)
353.877 μs (1560 allocations: 128.73 KiB)
60.347 μs (184 allocations: 18.97 KiB)
```