### PR TITLE
Update MPB_wrapper.jl

### DIFF
--- a/src/MPB_wrapper.jl
+++ b/src/MPB_wrapper.jl
@@ -757,3 +757,4 @@ end
 
 MPB.getsolvetime(m::GurobiMathProgModel) = get_runtime(m.inner)
 MPB.getnodecount(m::GurobiMathProgModel) = get_node_count(m.inner)
+MPB.getsimplexiter(m::GurobiMathProgModel) = get_dblattr(m.inner, "IterCount")


### PR DESCRIPTION
I added the line (line 760)

MPB.getsimplexiter(m::GurobiMathProgModel) = get_dblattr(m.inner, "IterCount")

to retrieve the number of simplex iteration. In my machine it works.