### PR TITLE
Remove support for Gurobi < v7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Here is the procedure to setup this package:
 
 1. Obtain a license of Gurobi and install Gurobi solver, following the instructions on [Gurobi's website](http://www.gurobi.com).
 
+   **The minimum version supported by *Gurobi.jl* is Gurobi v7.0.**
+
 2. Install this package using ``Pkg.add("Gurobi")``.
 
 3. Make sure the ``GUROBI_HOME`` environmental variable is set to the path of the Gurobi directory. This is part of a standard installation. The Gurobi library will be searched for in ``GUROBI_HOME/lib`` on unix platforms and ``GUROBI_HOME\bin`` on Windows. If the library is not found, check that your version is listed in ``deps/build.jl``.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -24,9 +24,7 @@ end
 
 const ALIASES = [
     "gurobi81", "gurobi80",
-    "gurobi75", "gurobi70",
-    "gurobi65", "gurobi60",
-    "gurobi56", "gurobi55"
+    "gurobi75", "gurobi70"
 ]
 
 paths_to_try = copy(ALIASES)


### PR DESCRIPTION
See the discussion: https://github.com/JuliaOpt/Gurobi.jl/issues/195#issuecomment-465160480

Gurobi 7.0 is the earliest version with documentation on the Gurobi website. 

Versions prior to v7 have different default behaviour with the `UpdateMode` parameter and so do not work with the MOI wrapper.