### PR TITLE
Compute IIS

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -733,15 +733,27 @@ conflict is not purged, and any calls to the above attributes will return values
 for the original conflict without a warning.
 """
 function compute_conflict(model::Optimizer)
-    computeIIS(model.inner)
+    try
+        computeIIS(model.inner)
+    catch exc
+        if isa(exc, GurobiError) && exc.code == 10015
+            model.inner.conflict = Gurobi.GRB_INFEASIBLE
+        else
+            rethrow(exc)
+        end
+    end
     return
 end
 
 function _ensure_conflict_computed(model::Optimizer)
-    if model.conflict == -1
+    if model.inner.conflict == -1
         error("Cannot access conflict status. Call `Gurobi.compute_conflict(model)` first. " *
               "In case the model is modified, the computed conflict will not be purged.")
     end
+end
+
+function _is_feasible(model::Optimizer)
+    return model.inner.conflict == Gurobi.GRB_INFEASIBLE
 end
 
 """
@@ -756,33 +768,35 @@ struct ConflictStatus <: MOI.AbstractModelAttribute  end
 MOI.is_set_by_optimize(::ConflictStatus) = true
 
 function MOI.get(model::Optimizer, ::ConflictStatus)
-    if model.conflict == -1
+    if model.inner.conflict == -1
         return MOI.OPTIMIZE_NOT_CALLED
-    elseif model.conflict == Gurobi.GRB_LOADED
-        return MOI.OTHER_ERROR
-    elseif model.conflict == Gurobi.GRB_OPTIMAL
+    elseif model.inner.conflict == 0
         return MOI.OPTIMAL
-    elseif model.conflict == Gurobi.GRB_INFEASIBLE
+    elseif model.inner.conflict == Gurobi.GRB_LOADED
+        return MOI.OTHER_ERROR
+    elseif model.inner.conflict == Gurobi.GRB_OPTIMAL
+        return MOI.OPTIMAL
+    elseif model.inner.conflict == Gurobi.GRB_INFEASIBLE
         return MOI.INFEASIBLE
-    elseif model.conflict == Gurobi.GRB_INF_OR_UNBD
+    elseif model.inner.conflict == Gurobi.GRB_INF_OR_UNBD
         return MOI.INFEASIBLE_OR_UNBOUNDED
-    elseif model.conflict == Gurobi.GRB_USER_OBJ_LIMIT
+    elseif model.inner.conflict == Gurobi.GRB_USER_OBJ_LIMIT
         return MOI.OBJECTIVE_LIMIT
-    elseif model.conflict == Gurobi.GRB_ITERATION_LIMIT
+    elseif model.inner.conflict == Gurobi.GRB_ITERATION_LIMIT
         return MOI.ITERATION_LIMIT
-    elseif model.conflict == Gurobi.GRB_NODE_LIMIT
+    elseif model.inner.conflict == Gurobi.GRB_NODE_LIMIT
         return MOI.NODE_LIMIT
-    elseif model.conflict == Gurobi.GRB_TIME_LIMIT
+    elseif model.inner.conflict == Gurobi.GRB_TIME_LIMIT
         return MOI.TIME_LIMIT
-    elseif model.conflict == Gurobi.GRB_SOLUTION_LIMIT
+    elseif model.inner.conflict == Gurobi.GRB_SOLUTION_LIMIT
         return MOI.SOLUTION_LIMIT
-    elseif model.conflict == Gurobi.GRB_INTERRUPTED
+    elseif model.inner.conflict == Gurobi.GRB_INTERRUPTED
         return MOI.INTERRUPTED
-    elseif model.conflict == Gurobi.GRB_NUMERIC
+    elseif model.inner.conflict == Gurobi.GRB_NUMERIC
         return MOI.NUMERICAL_ERROR
-    elseif model.conflict == Gurobi.GRB_SUBOPTIMAL
+    elseif model.inner.conflict == Gurobi.GRB_SUBOPTIMAL
         return MOI.OTHER_LIMIT
-    elseif model.conflict == Gurobi.GRB_INPROGRESS
+    elseif model.inner.conflict == Gurobi.GRB_INPROGRESS
         return MOI.OTHER_ERROR
     else
         return MOI.OTHER_ERROR
@@ -802,22 +816,28 @@ MOI.is_set_by_optimize(::ConstraintConflictStatus) = true
 
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.LE})
     _ensure_conflict_computed(model)
-    return Bool(get_intattrelement(model, "IISUB", model[index] - 1))
+    return !_is_feasible(model) && Bool(get_intattrelement(model.inner, "IISUB", LQOI.get_column(model, model[index])))
 end
 
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.GE})
     _ensure_conflict_computed(model)
-    return Bool(get_intattrelement(model, "IISLB", model[index] - 1))
+    return !_is_feasible(model) && Bool(get_intattrelement(model.inner, "IISLB", LQOI.get_column(model, model[index])))
 end
 
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:Union{LQOI.EQ, LQOI.IV}})
     _ensure_conflict_computed(model)
-    return Bool(get_intattrelement(model, "IISUB", model[index] - 1)) || Bool(get_intattrelement(model, "IISLB", model[index] - 1))
+    return !_is_feasible(model) && (
+        Bool(get_intattrelement(model.inner, "IISUB", LQOI.get_column(model, model[index]))) || Bool(get_intattrelement(model.inner, "IISLB", model[index])))
 end
 
 function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:Union{LQOI.LE, LQOI.GE, LQOI.EQ}})
     _ensure_conflict_computed(model)
-    return Bool(get_intattrelement(model, "IISConstr", model[index] - 1))
+    return !_is_feasible(model) && Bool(get_intattrelement(model.inner, "IISConstr", model[index]))
+end
+
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarQuadraticFunction, <:Union{LQOI.LE, LQOI.GE}})
+    _ensure_conflict_computed(model)
+    return !_is_feasible(model) && Bool(get_intattrelement(model.inner, "IISQConstr", model[index]))
 end
 
 function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.LinSets}})
@@ -825,5 +845,9 @@ function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.Constr
 end
 
 function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:Union{LQOI.LE, LQOI.GE, LQOI.EQ}}})
+    return true
+end
+
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.ScalarQuadraticFunction, <:Union{LQOI.LE, LQOI.GE}}})
     return true
 end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -719,3 +719,111 @@ function MOI.delete(model::Optimizer,
     delete!(dict, index)
     return
 end
+
+"""
+    compute_conflict(model::Optimizer)
+
+Compute a minimal subset of the constraints and variables that keep the model
+infeasible.
+
+See also `Gurobi.ConflictStatus` and `Gurobi.ConstraintConflictStatus`.
+
+Note that if `model` is modified after a call to `compute_conflict`, the
+conflict is not purged, and any calls to the above attributes will return values
+for the original conflict without a warning.
+"""
+function compute_conflict(model::Optimizer)
+    computeIIS(model.inner)
+    return
+end
+
+function _ensure_conflict_computed(model::Optimizer)
+    if model.conflict == -1
+        error("Cannot access conflict status. Call `Gurobi.compute_conflict(model)` first. " *
+              "In case the model is modified, the computed conflict will not be purged.")
+    end
+end
+
+"""
+    ConflictStatus()
+
+Return an `MOI.TerminationStatusCode` indicating the status of the last computed conflict.
+If a minimal conflict is found, it will return `MOI.OPTIMAL`. If the problem is feasible, it will
+return `MOI.INFEASIBLE`. If `compute_conflict` has not been called yet, it will return
+`MOI.OPTIMIZE_NOT_CALLED`.
+"""
+struct ConflictStatus <: MOI.AbstractModelAttribute  end
+MOI.is_set_by_optimize(::ConflictStatus) = true
+
+function MOI.get(model::Optimizer, ::ConflictStatus)
+    if model.conflict == -1
+        return MOI.OPTIMIZE_NOT_CALLED
+    elseif model.conflict == Gurobi.GRB_LOADED
+        return MOI.OTHER_ERROR
+    elseif model.conflict == Gurobi.GRB_OPTIMAL
+        return MOI.OPTIMAL
+    elseif model.conflict == Gurobi.GRB_INFEASIBLE
+        return MOI.INFEASIBLE
+    elseif model.conflict == Gurobi.GRB_INF_OR_UNBD
+        return MOI.INFEASIBLE_OR_UNBOUNDED
+    elseif model.conflict == Gurobi.GRB_USER_OBJ_LIMIT
+        return MOI.OBJECTIVE_LIMIT
+    elseif model.conflict == Gurobi.GRB_ITERATION_LIMIT
+        return MOI.ITERATION_LIMIT
+    elseif model.conflict == Gurobi.GRB_NODE_LIMIT
+        return MOI.NODE_LIMIT
+    elseif model.conflict == Gurobi.GRB_TIME_LIMIT
+        return MOI.TIME_LIMIT
+    elseif model.conflict == Gurobi.GRB_SOLUTION_LIMIT
+        return MOI.SOLUTION_LIMIT
+    elseif model.conflict == Gurobi.GRB_INTERRUPTED
+        return MOI.INTERRUPTED
+    elseif model.conflict == Gurobi.GRB_NUMERIC
+        return MOI.NUMERICAL_ERROR
+    elseif model.conflict == Gurobi.GRB_SUBOPTIMAL
+        return MOI.OTHER_LIMIT
+    elseif model.conflict == Gurobi.GRB_INPROGRESS
+        return MOI.OTHER_ERROR
+    else
+        return MOI.OTHER_ERROR
+    end
+end
+
+function MOI.supports(::Optimizer, ::ConflictStatus)
+    return true
+end
+
+"""
+    ConstraintConflictStatus()
+A Boolean constraint attribute indicating whether the constraint participates in the last computed conflict.
+"""
+struct ConstraintConflictStatus <: MOI.AbstractConstraintAttribute end
+MOI.is_set_by_optimize(::ConstraintConflictStatus) = true
+
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.LE})
+    _ensure_conflict_computed(model)
+    return Bool(get_intattrelement(model, "IISUB", model[index] - 1))
+end
+
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.GE})
+    _ensure_conflict_computed(model)
+    return Bool(get_intattrelement(model, "IISLB", model[index] - 1))
+end
+
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.SingleVariable, <:Union{LQOI.EQ, LQOI.IV}})
+    _ensure_conflict_computed(model)
+    return Bool(get_intattrelement(model, "IISUB", model[index] - 1)) || Bool(get_intattrelement(model, "IISLB", model[index] - 1))
+end
+
+function MOI.get(model::Optimizer, ::ConstraintConflictStatus, index::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:Union{LQOI.LE, LQOI.GE, LQOI.EQ}})
+    _ensure_conflict_computed(model)
+    return Bool(get_intattrelement(model, "IISConstr", model[index] - 1))
+end
+
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.SingleVariable, <:LQOI.LinSets}})
+    return true
+end
+
+function MOI.supports(::Optimizer, ::ConstraintConflictStatus, ::Type{MOI.ConstraintIndex{<:MOI.ScalarAffineFunction, <:Union{LQOI.LE, LQOI.GE, LQOI.EQ}}})
+    return true
+end

--- a/src/grb_constrs.jl
+++ b/src/grb_constrs.jl
@@ -12,7 +12,7 @@ end
 function add_constr!(model::Model, inds::IVec, coeffs::FVec, rel::Cchar, rhs::Float64)
     length(inds) == length(coeffs) || error("Inconsistent argument dimensions.")
     ret = @grb_ccall(addconstr, Cint, (
-        Ptr{Cvoid},    # model
+        Ptr{Cvoid},   # model
         Cint,         # numnz
         Ptr{Cint},    # cind
         Ptr{Float64}, # cvals

--- a/src/grb_model.jl
+++ b/src/grb_model.jl
@@ -11,9 +11,10 @@ mutable struct Model
     ptr_model::Ptr{Cvoid}
     callback::Any
     finalize_env::Bool
+    conflict::Integer
 
     function Model(env::Env, p::Ptr{Cvoid}; finalize_env::Bool=false)
-        model = new(env, p, nothing, finalize_env)
+        model = new(env, p, nothing, finalize_env, -1)
         if VERSION >= v"0.7-"
             finalizer(model) do m
                 free_model(m)

--- a/src/grb_quad.jl
+++ b/src/grb_quad.jl
@@ -7,7 +7,7 @@ function add_qpterms!(model::Model, qr::IVec, qc::IVec, qv::FVec)
 
     if nnz > 0
         ret = @grb_ccall(addqpterms, Cint, (
-            Ptr{Cvoid},    # model
+            Ptr{Cvoid},   # model
             Cint,         # nnz
             Ptr{Cint},    # qrow
             Ptr{Cint},    # qcol

--- a/src/grb_solve.jl
+++ b/src/grb_solve.jl
@@ -15,6 +15,7 @@ function computeIIS(model::Model)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end
+    model.conflict = ret
     nothing
 end
 
@@ -123,7 +124,8 @@ const varmap = Dict(
 
 const conmap = Dict(
      0 => :Basic,
-    -1 => :Nonbasic)
+    -1 => :Nonbasic
+)
 
 const basicmap_rev = Dict(
     :Superbasic => Cint(-3),

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -298,3 +298,166 @@ end
         end
     end
 end
+
+@testset "Conflict refiner" begin
+    @testset "Variable bounds (SingleVariable and LessThan/GreaterThan)" begin
+        model = Gurobi.Optimizer()
+        x = MOI.add_variable(model)
+        c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
+        c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        Gurobi.compute_conflict(model)
+        println(model.inner.conflict)
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMAL
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == true
+    end
+    
+    @testset "Variable bounds (ScalarAffine)" begin
+        model = Gurobi.Optimizer()
+        x = MOI.add_variable(model)
+        c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(2.0))
+        c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.LessThan(1.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        Gurobi.compute_conflict(model)
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMAL
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == true
+    end
+
+    @testset "Variable fixing (SingleVariable and EqualTo)" begin
+        model = Gurobi.Optimizer()
+        x = MOI.add_variable(model)
+        c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.EqualTo(1.0))
+        c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(2.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        Gurobi.compute_conflict(model)
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMAL
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == true
+    end
+
+    @testset "Variable bounds (SingleVariable and Interval)" begin
+        model = Gurobi.Optimizer()
+        x = MOI.add_variable(model)
+        c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.Interval(1.0, 3.0))
+        c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(0.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        Gurobi.compute_conflict(model)
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMAL
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == true
+    end
+
+    @testset "Two conflicting constraints (GreaterThan, LessThan)" begin
+        model = Gurobi.Optimizer()
+        x = MOI.add_variable(model)
+        y = MOI.add_variable(model)
+        b1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        b2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
+        c1 = MOI.add_constraint(model, cf1, MOI.LessThan(-1.0))
+        cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]), 0.0)
+        c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        Gurobi.compute_conflict(model)
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMAL
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), b1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), b2) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == false
+    end
+
+    @testset "Two conflicting constraints (EqualTo)" begin
+        model = Gurobi.Optimizer()
+        x = MOI.add_variable(model)
+        y = MOI.add_variable(model)
+        b1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        b2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
+        c1 = MOI.add_constraint(model, cf1, MOI.EqualTo(-1.0))
+        cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]), 0.0)
+        c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        Gurobi.compute_conflict(model)
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMAL
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), b1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), b2) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == false
+    end
+
+    @testset "Variables outside conflict" begin
+        model = Gurobi.Optimizer()
+        x = MOI.add_variable(model)
+        y = MOI.add_variable(model)
+        z = MOI.add_variable(model)
+        b1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        b2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+        b3 = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.GreaterThan(0.0))
+        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
+        c1 = MOI.add_constraint(model, cf1, MOI.LessThan(-1.0))
+        cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0, 1.0], [x, y, z]), 0.0)
+        c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(1.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        Gurobi.compute_conflict(model)
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMAL
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), b1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), b2) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), b3) == false
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == true
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == false
+    end
+
+    @testset "No conflict" begin
+        model = Gurobi.Optimizer()
+        x = MOI.add_variable(model)
+        c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(1.0))
+        c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.LessThan(2.0))
+
+        # Getting the results before the conflict refiner has been called must return an error. 
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
+
+        # Once it's called, no problem. 
+        Gurobi.compute_conflict(model)
+        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.INFEASIBLE
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == false
+        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == false
+    end
+end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -31,8 +31,7 @@ end
         solver = Gurobi.Optimizer(OutputFlag=0)
         MOIT.contlineartest(solver, MOIT.TestConfig(), [
             # This requires interval constraint.
-            "linear10",
-            "linear10b",
+            "linear10", "linear10b",
             # This requires an infeasiblity certificate for a variable bound.
             "linear12"
         ])

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -32,6 +32,7 @@ end
         MOIT.contlineartest(solver, MOIT.TestConfig(), [
             # This requires interval constraint.
             "linear10",
+            "linear10b",
             # This requires an infeasiblity certificate for a variable bound.
             "linear12"
         ])


### PR DESCRIPTION
Following https://github.com/JuliaOpt/JuMP.jl/issues/1035: implement IIS support in a third package. 

The low-level part was already done here, so I just added the MOI part (which required accessing the error code from the C API). 