### PR TITLE
Add diagnostic to build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -73,13 +73,24 @@ function diagnose_gurobi_install()
         println()
         println("Here are the files we searched:")
         dir = joinpath(ENV["GUROBI_HOME"], Sys.isunix() ? "lib" : "bin")
-        for file in readdir(dir)
-            println(" - ", joinpath(dir, file))
+        try
+            for file in readdir(dir)
+                println(" - ", joinpath(dir, file))
+            end
+            println("""
+            We were looking for (but could not find) a file named like
+            `libgurobiXXX.so`, `libgurobiXXX.dylib`, or `gurobiXXX.dll`
+            """)
+        catch ex
+            if typeof(ex) <: SystemError
+                println("""
+                Aha! Your GUROBI_HOME environment variable is wrong. It needs to
+                point to a valid directory.
+                """)
+            else
+                rethrow(ex)
+            end
         end
-        println("""
-        We were looking for (but could not find) a file named like
-        `libgurobiXXX.so`, `libgurobiXXX.dylib`, or `gurobiXXX.dll`
-        """)
     else
         try
             println("Looking for a version of Gurobi in your path:")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -54,6 +54,66 @@ for l in paths_to_try
     end
 end
 
+function diagnose_gurobi_install()
+    println("Unable to locate Gurobi installation. Running some common diagnostics.")
+    println()
+    println("Gurobi.jl only supports the following versions:")
+    println.(" - ", ALIASES)
+    println("Did you download and install one of these versions from gurobi.com?")
+    println()
+    if haskey(ENV, "GUROBI_HOME")
+        println("Found GUROBI_HOME = " * ENV["GUROBI_HOME"])
+        println("""
+        Does this point to the correct install location?
+        - on Windows, this might be `C:\\Program Files\\gurobi810\\win64\\`
+        - alternatively, on Windows, this might be `C:/Program Files/gurobi810/win64/`
+        - on OSX, this might be `/Library/gurobi810/mac64/`
+        - on Unix, this might be `/opt/gurobi810/linux64/`
+        """)
+        println()
+        println("Here are the files we searched:")
+        dir = joinpath(ENV["GUROBI_HOME"], Sys.isunix() ? "lib" : "bin")
+        for file in readdir(dir)
+            println(" - ", joinpath(dir, file))
+        end
+        println("""
+        We were looking for (but could not find) a file named like
+        `libgurobiXXX.so`, `libgurobiXXX.dylib`, or `gurobiXXX.dll`
+        """)
+    else
+        try
+            println("Looking for a version of Gurobi in your path:")
+            # Try to call `gurobi_cl`. This should work if Gurobi is on the
+            # system path. If it succeeds, it will print out the version.
+            run(`gurobi_cl --version`)
+            println("""
+
+            We couldn't find the `GUROBI_HOME` environment variable, but we
+            found this version of Gurobi on your path. Is it version one of
+            the supported versions listed above? If not, you should edit your
+            `PATH` to point to the correct version.
+            """)
+        catch
+            println("""
+            We could not find a version of Gurobi in your path, and we could
+            not find the environment variable `GUROBI_HOME` not. You should
+            set the `GUROBI_HOME` environment variable to point to the install
+            location. For example:
+            - on Windows, this might be `C:\\Program Files\\gurobi810\\win64\\`
+            - on OSX, this might be `/Library/gurobi810/mac64/`
+            - on Unix, this might be `/opt/gurobi810/linux64/`
+
+            Alternatively, you can add the Gurobi install directory to your path.
+            """)
+        end
+    end
+end
+
 if !found && !haskey(ENV, "GUROBI_JL_SKIP_LIB_CHECK")
-    error("Unable to locate Gurobi installation. Note that this must be downloaded separately from gurobi.com. For more information go to https://github.com/JuliaOpt/Gurobi.jl")
+    diagnose_gurobi_install()
+    error("""
+        Unable to locate Gurobi installation. If the advice above did not help,
+        open an issue at https://github.com/JuliaOpt/Gurobi.jl and post the full
+        print-out of this diagnostic attempt.
+    """)
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -84,8 +84,10 @@ function diagnose_gurobi_install()
         catch ex
             if typeof(ex) <: SystemError
                 println("""
-                Aha! Your GUROBI_HOME environment variable is wrong. It needs to
-                point to a valid directory.
+                Aha! We tried looking in `$(dir)`, but something went wrong. Are
+                you sure that your GUROBI_HOME environment variable is correct?
+                When combined with the appropriate suffix (e.g., `lib` or
+                `bin`, it needs to point to a valid directory.
                 """)
             else
                 rethrow(ex)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -68,7 +68,9 @@ function diagnose_gurobi_install()
         - on Windows, this might be `C:\\Program Files\\gurobi810\\win64\\`
         - alternatively, on Windows, this might be `C:/Program Files/gurobi810/win64/`
         - on OSX, this might be `/Library/gurobi810/mac64/`
-        - on Unix, this might be `/opt/gurobi810/linux64/`
+        - on Unix, this might be `/home/my_user/gurobi810/linux64/`
+        Note: this has the be the full path, not a path relative to your current
+        directory or your home directory.
         """)
         println()
         println("Here are the files we searched:")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -55,33 +55,46 @@ for l in paths_to_try
 end
 
 function diagnose_gurobi_install()
-    println("Unable to locate Gurobi installation. Running some common diagnostics.")
-    println()
-    println("Gurobi.jl only supports the following versions:")
+    println("""
+    Unable to locate Gurobi installation. Running some common diagnostics.
+
+    Gurobi.jl only supports the following versions:
+    """)
     println.(" - ", ALIASES)
-    println("Did you download and install one of these versions from gurobi.com?")
-    println()
+    println("""
+
+    Did you download and install one of these versions from gurobi.com?
+
+    """)
     if haskey(ENV, "GUROBI_HOME")
-        println("Found GUROBI_HOME = " * ENV["GUROBI_HOME"])
+        dir = joinpath(ENV["GUROBI_HOME"], Sys.isunix() ? "lib" : "bin")
         println("""
+        Found GUROBI_HOME =  $(ENV["GUROBI_HOME"])
+
         Does this point to the correct install location?
         - on Windows, this might be `C:\\Program Files\\gurobi810\\win64\\`
         - alternatively, on Windows, this might be `C:/Program Files/gurobi810/win64/`
         - on OSX, this might be `/Library/gurobi810/mac64/`
         - on Unix, this might be `/home/my_user/gurobi810/linux64/`
-        Note: this has the be the full path, not a path relative to your current
+
+        Note: this has to be a full path, not a path relative to your current
         directory or your home directory.
+
+        We're going to look for the Gurobi library in this directory:
+            $(dir)
+
+        That directory has the following files:
         """)
-        println()
-        println("Here are the files we searched:")
-        dir = joinpath(ENV["GUROBI_HOME"], Sys.isunix() ? "lib" : "bin")
         try
             for file in readdir(dir)
                 println(" - ", joinpath(dir, file))
             end
             println("""
+
             We were looking for (but could not find) a file named like
-            `libgurobiXXX.so`, `libgurobiXXX.dylib`, or `gurobiXXX.dll`
+            `libgurobiXXX.so`, `libgurobiXXX.dylib`, or `gurobiXXX.dll`. You
+            should update your GUROBI_HOME environment variable to point to the
+            correct location.
             """)
         catch ex
             if typeof(ex) <: SystemError
@@ -97,7 +110,9 @@ function diagnose_gurobi_install()
         end
     else
         try
-            println("Looking for a version of Gurobi in your path:")
+            println("""
+            Looking for a version of Gurobi in your path:
+            """)
             # Try to call `gurobi_cl`. This should work if Gurobi is on the
             # system path. If it succeeds, it will print out the version.
             run(`gurobi_cl --version`)
@@ -110,6 +125,7 @@ function diagnose_gurobi_install()
             """)
         catch
             println("""
+
             We could not find a version of Gurobi in your path, and we could
             not find the environment variable `GUROBI_HOME` not. You should
             set the `GUROBI_HOME` environment variable to point to the install
@@ -127,8 +143,8 @@ end
 if !found && !haskey(ENV, "GUROBI_JL_SKIP_LIB_CHECK")
     diagnose_gurobi_install()
     error("""
-        Unable to locate Gurobi installation. If the advice above did not help,
-        open an issue at https://github.com/JuliaOpt/Gurobi.jl and post the full
-        print-out of this diagnostic attempt.
+    Unable to locate Gurobi installation. If the advice above did not help,
+    open an issue at https://github.com/JuliaOpt/Gurobi.jl and post the full
+    print-out of this diagnostic attempt.
     """)
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -119,7 +119,7 @@ function diagnose_gurobi_install()
             println("""
 
             We couldn't find the `GUROBI_HOME` environment variable, but we
-            found this version of Gurobi on your path. Is it version one of
+            found this version of Gurobi on your path. Is this version one of
             the supported versions listed above? If not, you should edit your
             `PATH` to point to the correct version.
             """)
@@ -127,8 +127,8 @@ function diagnose_gurobi_install()
             println("""
 
             We could not find a version of Gurobi in your path, and we could
-            not find the environment variable `GUROBI_HOME` not. You should
-            set the `GUROBI_HOME` environment variable to point to the install
+            not find the environment variable `GUROBI_HOME`. You should set 
+            the `GUROBI_HOME` environment variable to point to the install
             location. For example:
             - on Windows, this might be `C:\\Program Files\\gurobi810\\win64\\`
             - on OSX, this might be `/Library/gurobi810/mac64/`


### PR DESCRIPTION
This PR adds a common diagnostic to the Gurobi install. It tries to catch and inform the user about common errors.

Closes #221