### PR TITLE
Add VectorOfVariables-in-SecondOrderCone

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2063,7 +2063,7 @@ function MOI.get(
     indices = MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.SecondOrderCone}[
         MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.SecondOrderCone}(key)
         for (key, info) in model.quadratic_constraint_info
-            if info.set.dimension > 0
+            if typeof(info.set) == MOI.SecondOrderCone
     ]
     return sort!(indices, by = x -> x.value)
 end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -906,17 +906,17 @@ function _set_variable_lower_bound(model, info, value)
         set_dblattrelement!(model.inner, "LB", info.column, value)
         _require_update(model)
     elseif isnan(info.lower_bound_if_soc)
-        # Previously, we had a +ve lower bound (i.e., it was set in the case
-        # above). Now we're setting this with a -ve one, but there are still
-        # some SOC constraints, so we cache `value` and set the variable lower
-        # bound to `0.0`.
+        # Previously, we had a non-negative lower bound (i.e., it was set in the
+        # case above). Now we're setting this with a negative one, but there are
+        # still some SOC constraints, so we cache `value` and set the variable
+        # lower bound to `0.0`.
         @assert value < 0.0
         set_dblattrelement!(model.inner, "LB", info.column, 0.0)
         _require_update(model)
         info.lower_bound_if_soc = value
     else
-        # Previously, we had a -ve lower bound. We're setting this with another
-        # -ve one, but there are still some SOC constraints.
+        # Previously, we had a negative lower bound. We're setting this with
+        # another negative one, but there are still some SOC constraints.
         @assert info.lower_bound_if_soc < 0.0
         info.lower_bound_if_soc = value
     end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -3,7 +3,9 @@ const MOIT = MOI.Test
 
 const GUROBI_ENV = Gurobi.Env()
 const OPTIMIZER = MOI.Bridges.full_bridge_optimizer(
-    Gurobi.Optimizer(GUROBI_ENV, OutputFlag=0), Float64
+    # Note: we set `DualReductions = 0` so that we never return
+    # `INFEASIBLE_OR_UNBOUNDED`.
+    Gurobi.Optimizer(GUROBI_ENV, OutputFlag=0, DualReductions=0), Float64
 )
 
 const CONFIG = MOIT.TestConfig()
@@ -44,12 +46,8 @@ end
 
 @testset "Conic tests" begin
     MOIT.lintest(OPTIMIZER, CONFIG)
-    MOIT.soctest(OPTIMIZER, MOIT.TestConfig(duals = false), [
-        # Test currently requires INFEASIBLE, while Gurobi returns
-        # INFEASIBLE_OR_UNBOUNDED.
-        "soc3"
-    ])
-    MOIT.rsoctest(OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-6))
+    MOIT.soctest(OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3))
+    MOIT.rsoctest(OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3))
     MOIT.geomeantest(OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3))
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -46,7 +46,11 @@ end
 
 @testset "Conic tests" begin
     MOIT.lintest(OPTIMIZER, CONFIG)
-    MOIT.soctest(OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3))
+    MOIT.soctest(OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3), ["soc3"])
+    MOIT.soc3test(
+        OPTIMIZER,
+        MOIT.TestConfig(duals = false, infeas_certificates = false, atol = 1e-3)
+    )
     MOIT.rsoctest(OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3))
     MOIT.geomeantest(OPTIMIZER, MOIT.TestConfig(duals = false, atol=1e-3))
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -724,7 +724,7 @@ end
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE
     end
-    @testset "+ve initial bound" begin
+    @testset "non-negative initial bound" begin
         MOI.empty!(model)
         t = MOI.add_variable(model)
         x = MOI.add_variables(model, 2)
@@ -743,7 +743,7 @@ end
         MOI.optimize!(model)
         @test MOI.get(model, MOI.VariablePrimal(), t) == 1.0
     end
-    @testset "-ve initial bound" begin
+    @testset "negative initial bound" begin
         MOI.empty!(model)
         t = MOI.add_variable(model)
         x = MOI.add_variables(model, 2)
@@ -762,7 +762,7 @@ end
         MOI.optimize!(model)
         @test MOI.get(model, MOI.VariablePrimal(), t) == -1.0
     end
-    @testset "+ve post bound" begin
+    @testset "non-negative post bound" begin
         MOI.empty!(model)
         t = MOI.add_variable(model)
         x = MOI.add_variables(model, 2)
@@ -781,7 +781,7 @@ end
         MOI.optimize!(model)
         @test MOI.get(model, MOI.VariablePrimal(), t) == 5.0
     end
-    @testset "-ve post bound" begin
+    @testset "negative post bound" begin
         MOI.empty!(model)
         t = MOI.add_variable(model)
         x = MOI.add_variables(model, 2)
@@ -800,7 +800,7 @@ end
         MOI.optimize!(model)
         @test MOI.get(model, MOI.VariablePrimal(), t) == -6.0
     end
-    @testset "-ve post bound II" begin
+    @testset "negative post bound II" begin
         MOI.empty!(model)
         t = MOI.add_variable(model)
         x = MOI.add_variables(model, 2)


### PR DESCRIPTION
There are a few todos:

In Gurobi.jl

- [x] Figure out how to set `t >= 0`

In MathOptInterface.jl

- [x] <s>Fix soc3 test to allow `INFEASIBLE_OR_UNBOUNDED` as a return https://github.com/JuliaOpt/MathOptInterface.jl/issues/836 https://github.com/JuliaOpt/MathOptInterface.jl/pull/839</s> We set `DualReductions=0`.
- [x] Implement `ConstraintFunction` and `ConstraintSet` in `geomean` bridge https://github.com/JuliaOpt/MathOptInterface.jl/issues/750

![image](https://user-images.githubusercontent.com/8177701/63051377-c0cab400-bea2-11e9-8858-7a07b6addf17.png)
