### PR TITLE
Bump MOI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Gurobi"
-repo = "https://github.com/JuliaOpt/Gurobi.jl"
 uuid = "2e9cd046-0924-5485-92f1-d5272153d98b"
+repo = "https://github.com/JuliaOpt/Gurobi.jl"
 version = "0.7.0"
 
 [deps]
@@ -12,7 +12,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-MathOptInterface = "~0.9.0"
+MathOptInterface = "~0.9.1"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
 julia = "1"
 


### PR DESCRIPTION
MOI v0.9.1 is needed for Gurobi to run properly on Julia v1.2. We should use this version in every package requiring MOI to decrease the chance of someone using MOI v0.9 on Julia v1.2.