### PR TITLE
Support VariablePrimalStart

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1967,6 +1967,7 @@ function MOI.get(
     return _info(model, x).start
 end
 
+MOI.supports(::Optimizer, ::MOI.VariablePrimalStart) = true
 MOI.supports(::Optimizer, ::MOI.ConstraintPrimalStart) = false
 MOI.supports(::Optimizer, ::MOI.ConstraintDualStart) = false
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -85,6 +85,7 @@ end
     @testset "start_values_test" begin
         model = Gurobi.Optimizer(GUROBI_ENV, OutputFlag = 0)
         x = MOI.add_variables(model, 2)
+        @test MOI.supports(model, MOI.VariablePrimalStart())
         MOI.set(model, MOI.VariablePrimalStart(), x[1], 1.0)
         MOI.set(model, MOI.VariablePrimalStart(), x[2], nothing)
         @test MOI.get(model, MOI.VariablePrimalStart(), x[1]) == 1.0


### PR DESCRIPTION
Start value still didn't work with JuMP: https://discourse.julialang.org/t/warning-invalid-warm-start-basis-discarded/26403/12?u=odow
because we needed to `MOI.supports` them.
<img width="573" alt="image" src="https://user-images.githubusercontent.com/8177701/63716376-7be03f00-c80b-11e9-8e56-2b5dbb4d21e9.png">

@blegat we should have a `VariablePrimalStart` test in MOI that doesn't require constraint primals.