### PR TITLE
Fix handling of duplicate names

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1614,6 +1614,7 @@ function MOI.set(
 ) where {S}
     info = _info(model, c)
     info.name = name
+    _update_if_necessary(model)
     set_strattrelement!(model.inner, "QCName", info.row, name)
     _require_update(model)
     model.name_to_constraint_index = nothing

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -848,3 +848,64 @@ end
         @test MOI.get(model, MOI.VariablePrimal(), t) == -1.0
     end
 end
+
+@testset "Duplicate names" begin
+    @testset "Variables" begin
+        model = Gurobi.Optimizer(GUROBI_ENV)
+        (x, y, z) = MOI.add_variables(model, 3)
+        MOI.set(model, MOI.VariableName(), x, "x")
+        MOI.set(model, MOI.VariableName(), y, "x")
+        MOI.set(model, MOI.VariableName(), z, "z")
+        @test MOI.get(model, MOI.VariableIndex, "z") == z
+        @test_throws ErrorException MOI.get(model, MOI.VariableIndex, "x")
+        MOI.set(model, MOI.VariableName(), y, "y")
+        @test MOI.get(model, MOI.VariableIndex, "x") == x
+        @test MOI.get(model, MOI.VariableIndex, "y") == y
+        MOI.set(model, MOI.VariableName(), z, "x")
+        @test_throws ErrorException MOI.get(model, MOI.VariableIndex, "x")
+        MOI.delete(model, x)
+        @test MOI.get(model, MOI.VariableIndex, "x") == z
+    end
+    @testset "SingleVariable" begin
+        model = Gurobi.Optimizer(GUROBI_ENV)
+        x = MOI.add_variables(model, 3)
+        c = MOI.add_constraints(model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
+        MOI.set(model, MOI.ConstraintName(), c[1], "x")
+        MOI.set(model, MOI.ConstraintName(), c[2], "x")
+        MOI.set(model, MOI.ConstraintName(), c[3], "z")
+        @test MOI.get(model, MOI.ConstraintIndex, "z") == c[3]
+        @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "x")
+        MOI.set(model, MOI.ConstraintName(), c[2], "y")
+        @test MOI.get(model, MOI.ConstraintIndex, "x") == c[1]
+        @test MOI.get(model, MOI.ConstraintIndex, "y") == c[2]
+        MOI.set(model, MOI.ConstraintName(), c[3], "x")
+        @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "x")
+        MOI.delete(model, c[1])
+        @test MOI.get(model, MOI.ConstraintIndex, "x") == c[3]
+        MOI.set(model, MOI.ConstraintName(), c[2], "x")
+        @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "x")
+        MOI.delete(model, x[3])
+        @test MOI.get(model, MOI.ConstraintIndex, "x") == c[2]
+    end
+    @testset "ScalarAffineFunction" begin
+        model = Gurobi.Optimizer(GUROBI_ENV)
+        x = MOI.add_variables(model, 3)
+        fs = [
+            MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, xi)], 0.0)
+            for xi in x
+        ]
+        c = MOI.add_constraints(model, fs, MOI.GreaterThan(0.0))
+        MOI.set(model, MOI.ConstraintName(), c[1], "x")
+        MOI.set(model, MOI.ConstraintName(), c[2], "x")
+        MOI.set(model, MOI.ConstraintName(), c[3], "z")
+        @test MOI.get(model, MOI.ConstraintIndex, "z") == c[3]
+        @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "x")
+        MOI.set(model, MOI.ConstraintName(), c[2], "y")
+        @test MOI.get(model, MOI.ConstraintIndex, "x") == c[1]
+        @test MOI.get(model, MOI.ConstraintIndex, "y") == c[2]
+        MOI.set(model, MOI.ConstraintName(), c[3], "x")
+        @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "x")
+        MOI.delete(model, c[1])
+        @test MOI.get(model, MOI.ConstraintIndex, "x") == c[3]
+    end
+end


### PR DESCRIPTION
Simplified (and corrected) handling of variable and constraint names. Note that instead of trying to maintain the name-to-X mapping, we just throw it away if anything changes. This is inefficient if your workflow is add-query-add-query-etc. But it should be fine for the most common work-flow of add a lot of things - query.

<img width="353" alt="image" src="https://user-images.githubusercontent.com/8177701/64913586-4e026200-d708-11e9-9b5d-1212713058b4.png">

Fixes #249 