### PR TITLE
Specialization of MOI.delete for vector of variables 

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -460,6 +460,27 @@ function MOI.is_valid(model::Optimizer, v::MOI.VariableIndex)
     return haskey(model.variable_info, v)
 end
 
+function MOI.delete(model::Optimizer, indices::Vector{<:MOI.VariableIndex})
+    _update_if_necessary(model)
+    info = _info.(model, indices)
+    soc_idx = findfirst(e -> e.num_soc_constraints > 0, info)
+    soc_idx !== nothing && throw(MOI.DeleteNotAllowed(indices[soc_idx]))
+    sorted_del_cols = sort!(collect(i.column for i in info))
+    del_vars!(model.inner, convert(Vector{Cint}, sorted_del_cols))
+    _require_update(model)
+    delete!.(model.variable_info, indices)
+    for other_info in values(model.variable_info)
+        other_info.column -= searchsortedlast(
+          sorted_del_cols, other_info.column
+        )
+    end
+    model.name_to_variable = nothing
+    # We throw away name_to_constraint_index so we will rebuild SingleVariable
+    # constraint names without v.
+    model.name_to_constraint_index = nothing
+    return
+end
+
 function MOI.delete(model::Optimizer, v::MOI.VariableIndex)
     _update_if_necessary(model)
     info = _info(model, v)


### PR DESCRIPTION
Arised from a discussion with @odow and @mlubin.

MOI.delete already has a fallback method for a vector of variable parameters (which just calls the single variable delete over each variable of the vector). The problem is that this fallback has O(n^2) performance the way the things are now (i.e., needing to update the model after each single variable deletion to keep the correspondence between MOI indexes and internal gurobi indexes). This specialization fixes the problem in an easy way but limited way (a better but much more complicated solution would be restructuring the whole lazy update implementation to keep a map between MOI indexes and internal Gurobi indexes).   