### PR TITLE
Fix GurobiError with unknown params

### DIFF
--- a/src/grb_env.jl
+++ b/src/grb_env.jl
@@ -1,23 +1,26 @@
 # Gurobi environment and other supporting facilities
 
+function _load_env()
+    a = Ref{Ptr{Cvoid}}()
+    ret = @grb_ccall(loadenv, Cint, (Ptr{Ptr{Cvoid}}, Ptr{UInt8}),
+        a, C_NULL)
+    if ret != 0
+        if ret == 10009
+            error("Invalid Gurobi license")
+        else
+            error("Failed to create environment (error $ret).")
+        end
+    end
+    return a[]
+end
 
 mutable struct Env
     ptr_env::Ptr{Cvoid}
 
-    function Env()
-        a = Ref{Ptr{Cvoid}}()
-        ret = @grb_ccall(loadenv, Cint, (Ptr{Ptr{Cvoid}}, Ptr{UInt8}),
-            a, C_NULL)
-        if ret != 0
-            if ret == 10009
-                error("Invalid Gurobi license")
-            else
-                error("Failed to create environment (error $ret).")
-            end
-        end
-        env = new(a[])
+    function Env(a::Ptr{Cvoid}=_load_env())
+        env = new(a)
         # finalizer(env, free_env)  ## temporary disable: which tends to sometimes caused warnings
-        env
+        return env
     end
 end
 

--- a/test/C/test_grb_params.jl
+++ b/test/C/test_grb_params.jl
@@ -1,0 +1,13 @@
+using Test, Gurobi
+
+@testset "GRB Parameters" begin
+    env = Gurobi.Env()
+    model = Gurobi.Model(env, "")
+
+    @test_throws Gurobi.GurobiError Gurobi.get_str_param(model, "Foobar")
+    @test_throws Gurobi.GurobiError Gurobi.set_str_param!(model, "Foobar", "")
+    @test_throws Gurobi.GurobiError Gurobi.get_int_param(model, "Foobar")
+    @test_throws Gurobi.GurobiError Gurobi.set_int_param!(model, "Foobar", 0)
+    @test_throws Gurobi.GurobiError Gurobi.get_dbl_param(model, "Foobar")
+    @test_throws Gurobi.GurobiError Gurobi.set_dbl_param!(model, "Foobar", 0.0)
+end


### PR DESCRIPTION
One test fails but it seems unrelated:
```
solve_const_scalar_objective: Test Failed at /home/blegat/.julia/dev/MathOptInterface/src/Test/UnitTests/unit_tests.jl:64
  Expression: ≈(MOI.get(model, MOI.ObjectiveValue()), objective_value, atol=atol, rtol=rtol)
   Evaluated: 3.0 ≈ 4.0 (atol=1.0e-8, rtol=1.0e-8)
Stacktrace:
 [1] #test_model_solution#12(::Float64, ::Array{Tuple{MathOptInterface.VariableIndex,Float64},1}, ::Nothing, ::Nothing, ::typeof(MathOptInterface.Test.test_model_solution), ::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, ::MathOptInterface.Test.TestConfig{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/UnitTests/unit_tests.jl:64
 [2] (::MathOptInterface.Test.var"#kw##test_model_solution")(::NamedTuple{(:objective_value, :variable_primal),Tuple{Float64,Array{Tuple{MathOptInterface.VariableIndex,Float64},1}}}, ::typeof(MathOptInterface.Test.test_model_solution), ::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, ::MathOptInterface.Test.TestConfig{Float64}) at ./none:0
 [3] solve_const_scalar_objective(::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, ::MathOptInterface.Test.TestConfig{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/UnitTests/modifications.jl:296
 [4] macro expansion at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:48 [inlined]
 [5] modificationtest(::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, ::MathOptInterface.Test.TestConfig{Float64}, ::Array{String,1}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:48
 [6] modificationtest(::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, ::MathOptInterface.Test.TestConfig{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:43
 [7] top-level scope at /home/blegat/.julia/dev/Gurobi/test/MOI_wrapper.jl:50
 [8] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1107
 [9] top-level scope at /home/blegat/.julia/dev/Gurobi/test/MOI_wrapper.jl:14
```
```julia
julia> Gurobi.version
v"8.0.1"
```
Closes https://github.com/JuliaOpt/Gurobi.jl/issues/290