### PR TITLE
Don't hide the error being thrown by Gurobi when it fails to compute …

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2578,15 +2578,7 @@ conflict is not purged, and any calls to the above attributes will return values
 for the original conflict without a warning.
 """
 function compute_conflict(model::Optimizer)
-    try
-        computeIIS(model.inner)
-    catch exc
-        if isa(exc, GurobiError) && exc.code == 10015
-            model.inner.conflict = Gurobi.GRB_INFEASIBLE
-        else
-            rethrow(exc)
-        end
-    end
+    computeIIS(model.inner)
     return
 end
 

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -403,11 +403,12 @@ end
         @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.OPTIMIZE_NOT_CALLED
         @test_throws ErrorException MOI.get(model, Gurobi.ConstraintConflictStatus(), c1)
 
-        # Once it's called, no problem.
-        Gurobi.compute_conflict(model)
-        @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.INFEASIBLE
-        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == false
-        @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == false
+        @test_throws Gurobi.GurobiError Gurobi.compute_conflict(model)
+        # TODO(odow): bypass Gurobi's IIS checker when underlying model is
+        # feasible.
+        # @test MOI.get(model, Gurobi.ConflictStatus()) == MOI.INFEASIBLE
+        # @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c1) == false
+        # @test MOI.get(model, Gurobi.ConstraintConflictStatus(), c2) == false
     end
 end
 


### PR DESCRIPTION
…the IIS

We shouldn't be hiding this error, because Gurobi behaves differently with continuous and mixed-integer models. See #307 for details.

<img width="457" alt="image" src="https://user-images.githubusercontent.com/8177701/79054570-b4525300-7c0b-11ea-8f29-e59b1283013b.png">

Closes #307.