### PR TITLE
Adds a specialization of MOI.delete that deletes a batch of constraints.

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1478,6 +1478,10 @@ function MOI.delete(
     del_constrs!(model.inner, rows_to_delete)
     _require_update(model)
     for (_, info) in model.affine_constraint_info
+        # The trick here is: searchsortedlast returns, in O(log n), the
+        # last index with a row smaller than info.row, over rows_to_delete
+        # this is the same as the number of rows deleted before it, and
+        # how much its value need to be shifted.
         info.row -= searchsortedlast(rows_to_delete, info.row)
     end
     cs_values = sort!(getfield.(cs, :value))

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -468,10 +468,10 @@ end
     end
 end
 
-@testset "Add constraints" begin
+@testset "Add and delete constraints" begin
     model = Gurobi.Optimizer(GUROBI_ENV)
     x = MOI.add_variables(model, 2)
-    MOI.add_constraints(
+    cs = MOI.add_constraints(
         model,
         [MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x[i])], 0.0) for i in 1:2],
         MOI.EqualTo.([0.0, 0.0])
@@ -479,6 +479,10 @@ end
     @test MOI.get(model, MOI.NumberOfConstraints{
         MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}
     }()) == 2
+    MOI.delete(model, cs)
+    @test iszero(MOI.get(model, MOI.NumberOfConstraints{
+        MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}
+    }()))
 end
 
 @testset "Extra name tests" begin


### PR DESCRIPTION
I have only did it for MOI.ScalarAffineFunction constraints. This is merely a performance improvement. JuMP and MathOptInterface already have batch constraint deletion fallbacks and they will correctly call this method when it is the case. I did not add new tests nor benchmarks, but did call `JuMP.delete` in my code (that had performance problems), checked if the method was really called (with a `println` already removed), and the performance difference was from 23.2 seconds to 0.531 seconds (~29k constraints deleted from ~36k constraints, the speedup was probably higher than the ~43x because I am timing two batch variable deletions in these measurements, instead of just the constraint deletion, and they did not change performance with the changes introduced by this commit).

I executed the Gurobi tests as usual:
[![2020-04-20-17-41-37-1920x1080.png](https://i.postimg.cc/SK11rsgd/2020-04-20-17-41-37-1920x1080.png)](https://postimg.cc/PLZMftsv)

@odow can you give it a look? If you want me to stop pinging you in these cases just tell me, I am never sure if I should or not. If you think it needs extra tests or a "minimal working benchmark" I can work on them asap.