### PR TITLE
Adds buffering for variables deleted.

### DIFF
--- a/src/MOI_callbacks.jl
+++ b/src/MOI_callbacks.jl
@@ -20,7 +20,9 @@ function MOI.set(model::Optimizer, ::CallbackFunction, f::Function)
         f(cb_data, cb_where)
         model.callback_state = CB_NONE
     end)
-    update_model!(model.inner)
+    # mark the update as necessary and immediately call for the update
+    _require_update(model)
+    _update_if_necessary(model)
     return
 end
 MOI.supports(::Optimizer, ::CallbackFunction) = true

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -454,9 +454,8 @@ function _info(model::Optimizer, key::MOI.VariableIndex)
 end
 
 function _get_next_column(model::Optimizer)
-    old_value = deepcopy(model.next_column)
     model.next_column += 1
-    return old_value
+    return model.next_column - 1
 end
 
 function MOI.add_variable(model::Optimizer)

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -493,35 +493,41 @@ end
 end
 
 @testset "Buffered deletion test" begin
-		# Check if the names of variables (could be any attribute that is not
-		# cached as the bounds are) are right if we remove some variables and
-		# add new ones without updating the model (and that they stay correct
-		# after updating the model, here done by `MOI.optimize!`, as the update
-		# needs to be done inside MOI code, that is aware of the lazy updates).
+    # Check if the VarHintVal of variables (could be any attribute that is not
+    # cached, the most common as: the bounds, name, and the start, are all
+    # cached) are right if we remove some variables and add new ones without
+    # updating the model (and that they stay correct after updating the model,
+    # here done by `MOI.optimize!`, as the update needs to be done inside MOI
+    # code, that is aware of the lazy updates).
     model = Gurobi.Optimizer(GUROBI_ENV)
-		vars = MOI.add_variables(model, 3)
-		var_names = ["x_1", "x_2", "x_3"]
-		MOI.set.(model, MOI.VariableName(), vars, var_names)
-		@test all(MOI.is_valid.(model, vars))
-		@test MOI.get.(model, MOI.VariableName(), vars) == var_names
-		MOI.delete(model, vars[2:3])
-		@test !MOI.is_valid(model, vars[2])
-		@test !MOI.is_valid(model, vars[3])
-		fourth_var = MOI.add_variable(model)
-		MOI.set(model, MOI.VariableName(), fourth_var, "x_4")
-		# Check before updating the model and after the delete+insert.
-		@test MOI.is_valid(model, vars[1])
-		@test "x_1" == MOI.get(model, MOI.VariableName(), vars[1])
-		@test MOI.is_valid(model, fourth_var)
-		@test "x_4" == MOI.get(model, MOI.VariableName(), fourth_var)
-		# Then optimize to force an update.
-		MOI.optimize!(model)
-		# And check again.
-		@test MOI.is_valid(model, vars[1])
-		@test "x_1" == MOI.get(model, MOI.VariableName(), vars[1])
-		@test MOI.is_valid(model, fourth_var)
-		@test "x_4" == MOI.get(model, MOI.VariableName(), fourth_var)
+    vars = MOI.add_variables(model, 3)
+    vars_obj = [7.0, 42.0, -0.5]
+    obj_attr = Gurobi.VariableAttribute("Obj")
+    MOI.set.(model, obj_attr, vars, vars_obj)
+    @test all(MOI.is_valid.(model, vars))
+    @test MOI.get.(model, obj_attr, vars) == vars_obj
+    MOI.delete(model, vars[[1, 3]])
+    @test !MOI.is_valid(model, vars[1])
+    @test !MOI.is_valid(model, vars[3])
+    fourth_var = MOI.add_variable(model)
+    fourth_var_obj = -77.0
+    MOI.set(model, obj_attr, fourth_var, fourth_var_obj)
+    # Check before updating the model and after the delete+insert.
+    @test !MOI.is_valid(model, vars[1])
+    @test !MOI.is_valid(model, vars[3])
+    @test MOI.is_valid(model, vars[2])
+    @test vars_obj[2] == MOI.get(model, obj_attr, vars[2])
+    @test MOI.is_valid(model, fourth_var)
+    @test fourth_var_obj == MOI.get(model, obj_attr, fourth_var)
+    # Then optimize to force an update.
+    MOI.optimize!(model)
+    # And check again.
+    @test MOI.is_valid(model, vars[2])
+    @test vars_obj[2] == MOI.get(model, obj_attr, vars[2])
+    @test MOI.is_valid(model, fourth_var)
+    @test fourth_var_obj == MOI.get(model, obj_attr, fourth_var)
 end
+
 
 @testset "Extra name tests" begin
     model = Gurobi.Optimizer(GUROBI_ENV)

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -492,6 +492,37 @@ end
     }()))
 end
 
+@testset "Buffered deletion test" begin
+		# Check if the names of variables (could be any attribute that is not
+		# cached as the bounds are) are right if we remove some variables and
+		# add new ones without updating the model (and that they stay correct
+		# after updating the model, here done by `MOI.optimize!`, as the update
+		# needs to be done inside MOI code, that is aware of the lazy updates).
+    model = Gurobi.Optimizer(GUROBI_ENV)
+		vars = MOI.add_variables(model, 3)
+		var_names = ["x_1", "x_2", "x_3"]
+		MOI.set.(model, MOI.VariableName(), vars, var_names)
+		@test all(MOI.is_valid.(model, vars))
+		@test MOI.get.(model, MOI.VariableName(), vars) == var_names
+		MOI.delete(model, vars[2:3])
+		@test !MOI.is_valid(model, vars[2])
+		@test !MOI.is_valid(model, vars[3])
+		fourth_var = MOI.add_variable(model)
+		MOI.set(model, MOI.VariableName(), fourth_var, "x_4")
+		# Check before updating the model and after the delete+insert.
+		@test MOI.is_valid(model, vars[1])
+		@test "x_1" == MOI.get(model, MOI.VariableName(), vars[1])
+		@test MOI.is_valid(model, fourth_var)
+		@test "x_4" == MOI.get(model, MOI.VariableName(), fourth_var)
+		# Then optimize to force an update.
+		MOI.optimize!(model)
+		# And check again.
+		@test MOI.is_valid(model, vars[1])
+		@test "x_1" == MOI.get(model, MOI.VariableName(), vars[1])
+		@test MOI.is_valid(model, fourth_var)
+		@test "x_4" == MOI.get(model, MOI.VariableName(), fourth_var)
+end
+
 @testset "Extra name tests" begin
     model = Gurobi.Optimizer(GUROBI_ENV)
     @testset "Variables" begin


### PR DESCRIPTION
Gurobi.Optimizer now have fields `next_column` and `columns_deleted_since_last_update`. The behavior now is to not force a update before deleting, but instead: update the list of variables in Julia side but not their column indexes, and save the column indexes of the ones deleted; when updating the model then update the column indexes in Julia side.

The code pass all tests. But maybe we need to devise new ones.

This fix #315 in my code (that unfortunately is not a MWE).

I will be out for about 2 hours now, @odow, after this I will check if you have suggested something to me to improve in this PR.