### PR TITLE
Change `Gurobi.MultiObjectiveWeight` to accept `Real`

### DIFF
--- a/src/MOI_wrapper/MOI_multi_objective.jl
+++ b/src/MOI_wrapper/MOI_multi_objective.jl
@@ -114,7 +114,7 @@ struct MultiObjectiveWeight <: MOI.AbstractModelAttribute
     index::Int
 end
 
-function MOI.set(model::Optimizer, attr::MultiObjectiveWeight, weight::Float64)
+function MOI.set(model::Optimizer, attr::MultiObjectiveWeight, weight::Real)
     MOI.set(model, MultiObjectiveAttribute(attr.index, "ObjNWeight"), weight)
     return
 end

--- a/src/MOI_wrapper/MOI_multi_objective.jl
+++ b/src/MOI_wrapper/MOI_multi_objective.jl
@@ -115,7 +115,11 @@ struct MultiObjectiveWeight <: MOI.AbstractModelAttribute
 end
 
 function MOI.set(model::Optimizer, attr::MultiObjectiveWeight, weight::Real)
-    MOI.set(model, MultiObjectiveAttribute(attr.index, "ObjNWeight"), weight)
+    MOI.set(
+        model,
+        MultiObjectiveAttribute(attr.index, "ObjNWeight"),
+        convert(Float64, weight),
+    )
     return
 end
 

--- a/test/MOI/MOI_multiobjective.jl
+++ b/test/MOI/MOI_multiobjective.jl
@@ -99,6 +99,11 @@ c4: y >= 0.25
     @test MOI.get(model, MOI.VariablePrimal(), y) ≈ BFS[3].y
     @test MOI.get(model, Gurobi.MultiObjectiveValue(1)) ≈ BFS[3].f1
     @test MOI.get(model, Gurobi.MultiObjectiveValue(2)) ≈ BFS[3].f2
+
+    MOI.set(model, Gurobi.MultiObjectiveWeight(1), 1)
+    MOI.set(model, Gurobi.MultiObjectiveWeight(2), 1)
+    @test MOI.get(model, Gurobi.MultiObjectiveWeight(1)) == 1.0
+    @test MOI.get(model, Gurobi.MultiObjectiveWeight(2)) == 1.0
 end
 
 function test_example_biobjective_knapsack()

--- a/test/MOI/MOI_multiobjective.jl
+++ b/test/MOI/MOI_multiobjective.jl
@@ -99,11 +99,11 @@ c4: y >= 0.25
     @test MOI.get(model, MOI.VariablePrimal(), y) ≈ BFS[3].y
     @test MOI.get(model, Gurobi.MultiObjectiveValue(1)) ≈ BFS[3].f1
     @test MOI.get(model, Gurobi.MultiObjectiveValue(2)) ≈ BFS[3].f2
-
     MOI.set(model, Gurobi.MultiObjectiveWeight(1), 1)
     MOI.set(model, Gurobi.MultiObjectiveWeight(2), 1)
     @test MOI.get(model, Gurobi.MultiObjectiveWeight(1)) == 1.0
     @test MOI.get(model, Gurobi.MultiObjectiveWeight(2)) == 1.0
+    return
 end
 
 function test_example_biobjective_knapsack()


### PR DESCRIPTION
If we provide an integer weight to `Gurobi.MultiObjectiveWeight`, no warning is throw except for when we call optimize:

```julia
julia> using JuMP

julia> using Gurobi

julia> mdl = Model(Gurobi.Optimizer)

A JuMP Model
├ solver: Gurobi
├ objective_sense: FEASIBILITY_SENSE
├ num_variables: 0
├ num_constraints: 0
└ Names registered in the model: none

julia> @variable(mdl, x <= 1)
x

julia> @variable(mdl, y <= 1)
y

julia> @objective(mdl, Max, [x, y])
2-element Vector{VariableRef}:
 x
 y

julia> MOI.set(mdl, Gurobi.MultiObjectiveWeight(1), 1)

julia> optimize!(mdl)
ERROR: MathOptInterface.UnsupportedAttribute{Gurobi.MultiObjectiveWeight}: Attribute Gurobi.MultiObjectiveWeight(1) is not supported by the model.
Stacktrace:
  [1] throw_set_error_fallback(model::Gurobi.Optimizer, attr::Gurobi.MultiObjectiveWeight, value::Int64; error_if_supported::MathOptInterface.SetAttributeNotAllowed{Gurobi.MultiObjectiveWeight})
    @ MathOptInterface ~/.julia/packages/MathOptInterface/03Qtw/src/attributes.jl:631
  [2] throw_set_error_fallback(model::Gurobi.Optimizer, attr::Gurobi.MultiObjectiveWeight, value::Int64)
    @ MathOptInterface ~/.julia/packages/MathOptInterface/03Qtw/src/attributes.jl:622
  [3] set(model::Gurobi.Optimizer, attr::Gurobi.MultiObjectiveWeight, args::Int64)
    @ MathOptInterface ~/.julia/packages/MathOptInterface/03Qtw/src/attributes.jl:595
  [4] set(b::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, attr::Gurobi.MultiObjectiveWeight, value::Int64)
    @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/03Qtw/src/Bridges/bridge_optimizer.jl:1091
  [5] _pass_attribute(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}, index_map::MathOptInterface.Utilities.IndexMap, attr::Gurobi.MultiObjectiveWeight)
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/03Qtw/src/Utilities/copy.jl:51
  [6] pass_attributes(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}, index_map::MathOptInterface.Utilities.IndexMap)
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/03Qtw/src/Utilities/copy.jl:38
  [7] default_copy_to(dest::MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, src::MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/03Qtw/src/Utilities/copy.jl:391
  [8] copy_to
    @ ~/.julia/packages/MathOptInterface/03Qtw/src/Bridges/bridge_optimizer.jl:448 [inlined]
  [9] optimize!
    @ ~/.julia/packages/MathOptInterface/03Qtw/src/MathOptInterface.jl:121 [inlined]
 [10] optimize!(m::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}})
    @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/03Qtw/src/Utilities/cachingoptimizer.jl:370
 [11] optimize!(model::Model; ignore_optimize_hook::Bool, _differentiation_backend::MathOptInterface.Nonlinear.SparseReverseMode, kwargs::@Kwargs{})
    @ JuMP ~/.julia/packages/JuMP/7eD71/src/optimizer_interface.jl:609
 [12] optimize!(model::Model)
    @ JuMP ~/.julia/packages/JuMP/7eD71/src/optimizer_interface.jl:560
 [13] top-level scope
    @ REPL[70]:1
 [14] top-level scope
    @ REPL:1
```


It took me a little too long to work out why I got this error, so this PR just changes the function to accept `Real` values.
BTW these new tests do fail without this patch.

I'd also be ok with just warning the user that they provided an `Int` when they call `MOI.set`

Thanks!